### PR TITLE
本番リリース: #65 運営者の自治体作成・admin招待オンボーディング

### DIFF
--- a/src/app/api/super/municipalities/[id]/admins/route.ts
+++ b/src/app/api/super/municipalities/[id]/admins/route.ts
@@ -1,0 +1,26 @@
+import { ok, bad, readJson } from "@/lib/api/http";
+import { getRepos } from "@/lib/db/repositories";
+import { requireSuper } from "@/lib/api/auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Body = { email?: string; name?: string };
+
+/** POST /api/super/municipalities/[id]/admins
+ *  指定自治体の admin を pre-provision + 招待トークン発行(#65) */
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const sess = await requireSuper();
+  if (sess instanceof Response) return sess;
+  const { id } = await params;
+  const b = await readJson<Body>(req);
+  if (!b.email?.trim() || !b.name?.trim()) return bad("email / name は必須です");
+  const inv = await getRepos().super.createAdminInvite({
+    municipalityId: id,
+    email: b.email.trim(),
+    name: b.name.trim(),
+    createdBy: sess.userId,
+  });
+  const url = `${new URL(req.url).origin}/signup?token=${inv.token}`;
+  return ok({ ...inv, url }, 201);
+}

--- a/src/app/api/super/municipalities/route.ts
+++ b/src/app/api/super/municipalities/route.ts
@@ -1,0 +1,22 @@
+import { ok, bad, readJson } from "@/lib/api/http";
+import { getRepos } from "@/lib/db/repositories";
+import { requireSuper } from "@/lib/api/auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Body = { name?: string; prefecture?: string; annualBudget?: number };
+
+/** POST /api/super/municipalities — 運営者が自治体を新規作成(#65) */
+export async function POST(req: Request) {
+  const sess = await requireSuper();
+  if (sess instanceof Response) return sess;
+  const b = await readJson<Body>(req);
+  if (!b.name?.trim() || !b.prefecture?.trim()) return bad("name / prefecture は必須です");
+  const m = await getRepos().super.createMunicipality({
+    name: b.name.trim(),
+    prefecture: b.prefecture.trim(),
+    annualBudget: b.annualBudget,
+  });
+  return ok(m, 201);
+}

--- a/src/app/super/_app.tsx
+++ b/src/app/super/_app.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import * as React from "react";
-import { apiGet } from "@/lib/api/client";
-import { Building2, Users, Activity, ShieldCheck, Loader2, LogOut } from "lucide-react";
+import { apiGet, apiPost } from "@/lib/api/client";
+import { Building2, Users, Activity, ShieldCheck, Loader2, LogOut, Plus, UserPlus, Copy, Check, X } from "lucide-react";
 
 /* ============================================================
-   super 運営者ダッシュボード(#64)
-   全自治体横断のサマリ。super ロールのみアクセス可。
+   super 運営者ダッシュボード(#64 / #65)
+   全自治体横断のサマリ + 自治体作成・admin 招待オンボーディング。
+   super ロールのみアクセス可。
    ============================================================ */
 
 type MuniRow = {
@@ -26,12 +27,16 @@ type Overview = {
 export function SuperApp() {
   const [data, setData] = React.useState<Overview | null>(null);
   const [error, setError] = React.useState<string | null>(null);
+  const [muniModal, setMuniModal] = React.useState(false);
+  const [inviteFor, setInviteFor] = React.useState<{ id: string; name: string } | null>(null);
 
-  React.useEffect(() => {
+  const load = React.useCallback(() => {
     apiGet<Overview>("/api/super/overview")
-      .then(setData)
+      .then((d) => { setData(d); setError(null); })
       .catch(() => setError("データの取得に失敗しました(super 権限が必要です)"));
   }, []);
+
+  React.useEffect(() => { load(); }, [load]);
 
   async function handleLogout() {
     await fetch("/api/auth/logout", { method: "POST" });
@@ -74,8 +79,16 @@ export function SuperApp() {
               <StatCard icon={<ShieldCheck className="h-4 w-4" />} label="運営者(super)" value={data.totals.supers} />
             </div>
 
-            {/* 自治体一覧 */}
-            <h2 className="mt-8 mb-3 text-[13px] font-bold text-slate-700">契約自治体</h2>
+            {/* 自治体一覧 + 操作 */}
+            <div className="mt-8 mb-3 flex items-center justify-between">
+              <h2 className="text-[13px] font-bold text-slate-700">契約自治体</h2>
+              <button
+                onClick={() => setMuniModal(true)}
+                className="inline-flex items-center gap-1 rounded-lg bg-slate-900 px-3 py-1.5 text-[12px] font-bold text-white hover:bg-slate-800"
+              >
+                <Plus className="h-3.5 w-3.5" /> 自治体を追加
+              </button>
+            </div>
             <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
               <table className="w-full text-[13px]">
                 <thead className="bg-slate-50 text-[11px] uppercase text-slate-500">
@@ -85,6 +98,7 @@ export function SuperApp() {
                     <th className="px-4 py-2.5 text-right">隊員</th>
                     <th className="px-4 py-2.5 text-right">職員</th>
                     <th className="px-4 py-2.5 text-right">活動記録</th>
+                    <th className="px-4 py-2.5 text-right">操作</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-slate-100">
@@ -100,11 +114,19 @@ export function SuperApp() {
                           {m.activityLogs}
                         </span>
                       </td>
+                      <td className="px-4 py-2.5 text-right">
+                        <button
+                          onClick={() => setInviteFor({ id: m.id, name: m.name })}
+                          className="inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-[11px] font-semibold text-slate-700 hover:bg-slate-100"
+                        >
+                          <UserPlus className="h-3 w-3" /> 管理者を招待
+                        </button>
+                      </td>
                     </tr>
                   ))}
                   {data.municipalities.length === 0 && (
                     <tr>
-                      <td colSpan={5} className="px-4 py-8 text-center text-slate-400">契約自治体がありません</td>
+                      <td colSpan={6} className="px-4 py-8 text-center text-slate-400">契約自治体がありません</td>
                     </tr>
                   )}
                 </tbody>
@@ -113,6 +135,16 @@ export function SuperApp() {
           </>
         )}
       </div>
+
+      {muniModal && (
+        <MuniModal
+          onClose={() => setMuniModal(false)}
+          onCreated={() => { setMuniModal(false); load(); }}
+        />
+      )}
+      {inviteFor && (
+        <InviteModal muni={inviteFor} onClose={() => setInviteFor(null)} />
+      )}
     </main>
   );
 }
@@ -126,5 +158,110 @@ function StatCard({ icon, label, value }: { icon: React.ReactNode; label: string
       </div>
       <div className="mt-1 text-2xl font-bold tabular-nums">{value}</div>
     </div>
+  );
+}
+
+function Modal({ title, onClose, children }: { title: string; onClose: () => void; children: React.ReactNode }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" onClick={onClose}>
+      <div className="w-full max-w-sm rounded-2xl bg-white p-5 shadow-xl" onClick={(e) => e.stopPropagation()}>
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-[14px] font-bold">{title}</h3>
+          <button onClick={onClose} className="text-slate-400 hover:text-slate-700"><X className="h-4 w-4" /></button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function MuniModal({ onClose, onCreated }: { onClose: () => void; onCreated: () => void }) {
+  const [name, setName] = React.useState("");
+  const [prefecture, setPrefecture] = React.useState("");
+  const [budget, setBudget] = React.useState("2000000");
+  const [busy, setBusy] = React.useState(false);
+  const [err, setErr] = React.useState("");
+
+  async function submit() {
+    if (!name.trim() || !prefecture.trim()) { setErr("自治体名・都道府県は必須です"); return; }
+    setBusy(true); setErr("");
+    try {
+      await apiPost("/api/super/municipalities", { name: name.trim(), prefecture: prefecture.trim(), annualBudget: Number(budget) || undefined });
+      onCreated();
+    } catch (e) { setErr((e as Error).message); setBusy(false); }
+  }
+
+  return (
+    <Modal title="自治体を追加" onClose={onClose}>
+      <div className="space-y-3">
+        <Field label="自治体名"><input value={name} onChange={(e) => setName(e.target.value)} placeholder="例: 新温泉町" className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" /></Field>
+        <Field label="都道府県"><input value={prefecture} onChange={(e) => setPrefecture(e.target.value)} placeholder="例: 兵庫県" className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" /></Field>
+        <Field label="年間活動費枠(円)"><input value={budget} onChange={(e) => setBudget(e.target.value)} inputMode="numeric" className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" /></Field>
+        {err && <p className="text-[12px] text-rose-500">{err}</p>}
+        <button onClick={submit} disabled={busy} className="w-full rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-bold text-white disabled:opacity-40">
+          {busy ? "作成中…" : "作成する"}
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+function InviteModal({ muni, onClose }: { muni: { id: string; name: string }; onClose: () => void }) {
+  const [email, setEmail] = React.useState("");
+  const [name, setName] = React.useState("");
+  const [busy, setBusy] = React.useState(false);
+  const [err, setErr] = React.useState("");
+  const [url, setUrl] = React.useState<string | null>(null);
+  const [copied, setCopied] = React.useState(false);
+
+  async function submit() {
+    if (!email.trim() || !name.trim()) { setErr("メール・氏名は必須です"); return; }
+    setBusy(true); setErr("");
+    try {
+      const res = await apiPost<{ url: string }>(`/api/super/municipalities/${muni.id}/admins`, { email: email.trim(), name: name.trim() });
+      setUrl(res.url);
+    } catch (e) { setErr((e as Error).message); } finally { setBusy(false); }
+  }
+
+  async function copy() {
+    if (!url) return;
+    await navigator.clipboard.writeText(url).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <Modal title={`${muni.name} の管理者を招待`} onClose={onClose}>
+      {url ? (
+        <div className="space-y-3">
+          <p className="text-[13px] text-slate-600">招待リンクを発行しました。この URL を管理者に渡してください(7日間有効)。</p>
+          <div className="flex items-center gap-2">
+            <input readOnly value={url} className="w-full rounded-lg border border-slate-300 bg-slate-50 px-3 py-2 text-[12px]" />
+            <button onClick={copy} className="inline-flex items-center gap-1 rounded-lg bg-slate-900 px-3 py-2 text-[12px] font-bold text-white">
+              {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}{copied ? "コピー済" : "コピー"}
+            </button>
+          </div>
+          <button onClick={onClose} className="w-full rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-bold text-slate-700">閉じる</button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <Field label="管理者の氏名"><input value={name} onChange={(e) => setName(e.target.value)} placeholder="例: 山田 太郎" className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" /></Field>
+          <Field label="メールアドレス"><input value={email} onChange={(e) => setEmail(e.target.value)} type="email" placeholder="admin@example.jp" className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" /></Field>
+          {err && <p className="text-[12px] text-rose-500">{err}</p>}
+          <button onClick={submit} disabled={busy} className="w-full rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-bold text-white disabled:opacity-40">
+            {busy ? "発行中…" : "招待リンクを発行"}
+          </button>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-[11px] font-bold text-slate-500">{label}</span>
+      {children}
+    </label>
   );
 }

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -30,3 +30,11 @@ export async function requireAppUser(): Promise<{ authId: string; userId: string
   if (!appUser) return bad("このアカウントは未登録です(管理者の招待が必要です)", 403);
   return { authId, userId: appUser.id, role: appUser.role };
 }
+
+/** 運営者(super)専用ルートの先頭で呼ぶ。super 以外は 403。 */
+export async function requireSuper(): Promise<{ authId: string; userId: string; role: string } | Response> {
+  const sess = await requireAppUser();
+  if (sess instanceof Response) return sess;
+  if (sess.role !== "super") return bad("運営者(super)権限が必要です", 403);
+  return sess;
+}

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -93,6 +93,29 @@ export const sqliteRepos: Repos = {
         },
       };
     },
+
+    async createMunicipality(m) {
+      const id = genId("muni");
+      run("INSERT INTO municipalities (id,name,prefecture,annual_budget) VALUES (?,?,?,?)", [id, m.name, m.prefecture, m.annualBudget ?? 2000000]);
+      return { id, name: m.name, prefecture: m.prefecture };
+    },
+
+    async createAdminInvite(a) {
+      const muni = get<{ name: string }>("SELECT name FROM municipalities WHERE id=?", [a.municipalityId]);
+      // admin を pre-provision(/api/auth/me が email で auth_id を紐づけられるよう先に行を作る)
+      run(
+        `INSERT INTO users (id,municipality_id,organization_type,role,name,email,status)
+         VALUES (?,?,?,?,?,?,?)`,
+        [genId("adm"), a.municipalityId, "municipality", "admin", a.name, a.email, "active"]
+      );
+      const token = Array.from(crypto.getRandomValues(new Uint8Array(24))).map((b) => b.toString(16).padStart(2, "0")).join("");
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+      run(
+        `INSERT INTO invite_tokens (token,email,role,municipality_name,created_by,expires_at) VALUES (?,?,?,?,?,?)`,
+        [token, a.email, "admin", muni?.name ?? "", a.createdBy, expiresAt]
+      );
+      return { token, expiresAt };
+    },
   },
 
   members: {

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -108,6 +108,39 @@ export const supabaseRepos: Repos = {
         },
       };
     },
+
+    async createMunicipality(m) {
+      const { data } = await supabase()
+        .from("municipalities")
+        .insert({ name: m.name, prefecture: m.prefecture, annual_budget: m.annualBudget ?? 2000000 })
+        .select("id,name,prefecture")
+        .single();
+      return { id: data!.id, name: data!.name, prefecture: data!.prefecture };
+    },
+
+    async createAdminInvite(a) {
+      const { data: muni } = await supabase().from("municipalities").select("name").eq("id", a.municipalityId).maybeSingle();
+      // admin を pre-provision(/api/auth/me が email で auth_id を紐づけられるよう先に行を作る)
+      await supabase().from("users").insert({
+        municipality_id: a.municipalityId,
+        organization_type: "municipality",
+        role: "admin",
+        name: a.name,
+        email: a.email,
+        status: "active",
+      });
+      const token = Array.from(crypto.getRandomValues(new Uint8Array(24))).map((b) => b.toString(16).padStart(2, "0")).join("");
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+      await supabase().from("invite_tokens").insert({
+        token,
+        email: a.email,
+        role: "admin",
+        municipality_name: muni?.name ?? "",
+        created_by: a.createdBy,
+        expires_at: expiresAt,
+      });
+      return { token, expiresAt };
+    },
   },
 
   members: {

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -90,6 +90,10 @@ export interface Repos {
   };
   super: {
     overview(): Promise<SuperOverview>;
+    /** #65: 運営者が自治体を新規作成 */
+    createMunicipality(m: { name: string; prefecture: string; annualBudget?: number }): Promise<{ id: string; name: string; prefecture: string }>;
+    /** #65: 指定自治体の admin を pre-provision + 招待トークン発行(url は Route 側で付与) */
+    createAdminInvite(a: { municipalityId: string; email: string; name: string; createdBy: string }): Promise<{ token: string; expiresAt: string }>;
   };
   members: {
     list(): Promise<MemberDTO[]>;


### PR DESCRIPTION
develop(bfc6df4)を本番(main)へ。Issue #65。

## 変更
- 運営者(super)ダッシュボードに自治体作成・admin招待機能を追加
  - `requireSuper()` ガード / repos `super.createMunicipality`・`createAdminInvite`
  - `POST /api/super/municipalities`、`POST /api/super/municipalities/[id]/admins`
  - UI: 「自治体を追加」「管理者を招待」(招待URL表示+コピー)
- admin は users 行を事前プロビジョニング → 招待リンクで signup → /api/auth/me が email で紐づけ

## 検証
- typecheck クリーン / next build 成功 / in-memory SQLite で INSERT 整合
- migration 不要(role=super / municipality_id nullable は適用済み)

## マージ後
- 本番で super アカウントから /super → 自治体追加・管理者招待が使える
- 追加の env / Supabase 作業は不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)