### PR TITLE
feat: 運営者(super)に4機能を追加(ドリルダウン/アカウント管理/契約/横断KPI)

### DIFF
--- a/src/app/api/super/analytics/route.ts
+++ b/src/app/api/super/analytics/route.ts
@@ -1,0 +1,13 @@
+import { ok } from "@/lib/api/http";
+import { getRepos } from "@/lib/db/repositories";
+import { requireSuper } from "@/lib/api/auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** GET /api/super/analytics — 全国横断 KPI(super 専用) */
+export async function GET() {
+  const sess = await requireSuper();
+  if (sess instanceof Response) return sess;
+  return ok(await getRepos().super.analytics());
+}

--- a/src/app/api/super/municipalities/[id]/contract/route.ts
+++ b/src/app/api/super/municipalities/[id]/contract/route.ts
@@ -1,0 +1,35 @@
+import { ok, bad, readJson } from "@/lib/api/http";
+import { getRepos } from "@/lib/db/repositories";
+import { requireSuper } from "@/lib/api/auth";
+import type { ContractPatch } from "@/lib/db/repositories/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** GET /api/super/municipalities/[id]/contract — 契約情報(super 専用) */
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const sess = await requireSuper();
+  if (sess instanceof Response) return sess;
+  const { id } = await params;
+  const contract = await getRepos().super.getContract(id);
+  if (!contract) return bad("自治体が見つかりません", 404);
+  return ok(contract);
+}
+
+/** PATCH /api/super/municipalities/[id]/contract — 契約情報の部分更新(super 専用) */
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const sess = await requireSuper();
+  if (sess instanceof Response) return sess;
+  const { id } = await params;
+  const b = await readJson<ContractPatch>(req);
+
+  if (b.annualBudget !== undefined) {
+    if (typeof b.annualBudget !== "number" || Number.isNaN(b.annualBudget) || b.annualBudget < 0) {
+      return bad("年間活動費枠の値が不正です", 400);
+    }
+  }
+
+  const updated = await getRepos().super.updateContract(id, b);
+  if (!updated) return bad("自治体が見つかりません", 404);
+  return ok(updated);
+}

--- a/src/app/api/super/municipalities/[id]/route.ts
+++ b/src/app/api/super/municipalities/[id]/route.ts
@@ -1,0 +1,16 @@
+import { ok, bad } from "@/lib/api/http";
+import { getRepos } from "@/lib/db/repositories";
+import { requireSuper } from "@/lib/api/auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** GET /api/super/municipalities/[id] — 自治体ドリルダウン詳細(super 専用) */
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const sess = await requireSuper();
+  if (sess instanceof Response) return sess;
+  const { id } = await params;
+  const detail = await getRepos().super.municipalityDetail(id);
+  if (!detail) return bad("自治体が見つかりません", 404);
+  return ok(detail);
+}

--- a/src/app/api/super/users/[id]/route.ts
+++ b/src/app/api/super/users/[id]/route.ts
@@ -1,0 +1,33 @@
+import { ok, bad, readJson } from "@/lib/api/http";
+import { getRepos } from "@/lib/db/repositories";
+import { requireSuper } from "@/lib/api/auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const ROLES = ["member", "manager", "admin", "super"];
+const STATUSES = ["active", "retired", "suspended"];
+
+type PatchBody = { role?: string; status?: string; municipalityId?: string };
+
+/** PATCH /api/super/users/[id] — role/status/所属自治体の更新(super 専用) */
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const sess = await requireSuper();
+  if (sess instanceof Response) return sess;
+  const { id } = await params;
+  const b = await readJson<PatchBody>(req);
+
+  if (b.role !== undefined && !ROLES.includes(b.role)) return bad("role の値が不正です", 400);
+  if (b.status !== undefined && !STATUSES.includes(b.status)) return bad("status の値が不正です", 400);
+
+  // 事故防止: super 自身の降格 / 無効化をブロック
+  if (sess.userId && sess.userId === id) {
+    if ((b.role !== undefined && b.role !== "super") || b.status === "suspended") {
+      return bad("自分自身は変更できません", 400);
+    }
+  }
+
+  const updated = await getRepos().super.updateUser(id, b);
+  if (!updated) return bad("ユーザーが見つかりません", 404);
+  return ok(updated);
+}

--- a/src/app/api/super/users/route.ts
+++ b/src/app/api/super/users/route.ts
@@ -1,0 +1,20 @@
+import { ok } from "@/lib/api/http";
+import { getRepos } from "@/lib/db/repositories";
+import { requireSuper } from "@/lib/api/auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** GET /api/super/users — 全自治体横断のユーザー一覧(super 専用) */
+export async function GET(req: Request) {
+  const sess = await requireSuper();
+  if (sess instanceof Response) return sess;
+
+  const sp = new URL(req.url).searchParams;
+  const opts = {
+    municipalityId: sp.get("municipalityId") ?? undefined,
+    role: sp.get("role") ?? undefined,
+    status: sp.get("status") ?? undefined,
+  };
+  return ok(await getRepos().super.listUsers(opts));
+}

--- a/src/app/super/_app.tsx
+++ b/src/app/super/_app.tsx
@@ -1,12 +1,35 @@
 "use client";
 
 import * as React from "react";
-import { apiGet, apiPost } from "@/lib/api/client";
-import { Building2, Users, Activity, ShieldCheck, Loader2, LogOut, Plus, UserPlus, Copy, Check, X } from "lucide-react";
+import { apiGet, apiPost, apiPatch } from "@/lib/api/client";
+import {
+  Building2,
+  Users,
+  Activity,
+  ShieldCheck,
+  Loader2,
+  LogOut,
+  Plus,
+  UserPlus,
+  Copy,
+  Check,
+  X,
+  ClipboardCheck,
+  TrendingUp,
+  TrendingDown,
+  FileText,
+} from "lucide-react";
+import type {
+  SuperMuniDetail,
+  SuperUserRow,
+  ContractDTO,
+  SuperAnalytics,
+} from "@/lib/db/repositories/types";
 
 /* ============================================================
-   super 運営者ダッシュボード(#64 / #65)
-   全自治体横断のサマリ + 自治体作成・admin 招待オンボーディング。
+   super 運営者ダッシュボード(#64 / #65 / #66)
+   全自治体横断のサマリ + 自治体作成・admin 招待オンボーディング(#65)
+   + 自治体ドリルダウン・アカウント管理・契約管理・分析(#66)。
    super ロールのみアクセス可。
    ============================================================ */
 
@@ -24,19 +47,51 @@ type Overview = {
   totals: { municipalities: number; members: number; managers: number; admins: number; supers: number };
 };
 
+type Tab = "overview" | "accounts" | "analytics";
+
+const PLAN_LABEL: Record<ContractDTO["plan"], string> = { year1: "Year1", year2: "Year2", year3: "Year3" };
+const STATUS_LABEL: Record<ContractDTO["contractStatus"], string> = {
+  trial: "トライアル",
+  active: "契約中",
+  suspended: "停止",
+  ended: "終了",
+};
+
 export function SuperApp() {
   const [data, setData] = React.useState<Overview | null>(null);
   const [error, setError] = React.useState<string | null>(null);
+  const [tab, setTab] = React.useState<Tab>("overview");
+
+  // #65 オンボーディング モーダル
   const [muniModal, setMuniModal] = React.useState(false);
   const [inviteFor, setInviteFor] = React.useState<{ id: string; name: string } | null>(null);
 
-  const load = React.useCallback(() => {
+  // #66 自治体詳細(スライドオーバー)
+  const [detailId, setDetailId] = React.useState<string | null>(null);
+  const [detail, setDetail] = React.useState<SuperMuniDetail | null>(null);
+  const [detailErr, setDetailErr] = React.useState<string | null>(null);
+
+  // #66 契約モーダル
+  const [contractId, setContractId] = React.useState<string | null>(null);
+
+  const loadOverview = React.useCallback(() => {
     apiGet<Overview>("/api/super/overview")
       .then((d) => { setData(d); setError(null); })
       .catch(() => setError("データの取得に失敗しました(super 権限が必要です)"));
   }, []);
 
-  React.useEffect(() => { load(); }, [load]);
+  React.useEffect(() => {
+    loadOverview();
+  }, [loadOverview]);
+
+  function openDetail(id: string) {
+    setDetailId(id);
+    setDetail(null);
+    setDetailErr(null);
+    apiGet<SuperMuniDetail>(`/api/super/municipalities/${id}`)
+      .then(setDetail)
+      .catch(() => setDetailErr("詳細の取得に失敗しました"));
+  }
 
   async function handleLogout() {
     await fetch("/api/auth/logout", { method: "POST" });
@@ -57,6 +112,27 @@ export function SuperApp() {
         </button>
       </header>
 
+      {/* タブ */}
+      <div className="border-b border-slate-200 bg-white px-6">
+        <div className="mx-auto flex max-w-5xl gap-1">
+          {([
+            ["overview", "概要"],
+            ["accounts", "アカウント"],
+            ["analytics", "分析"],
+          ] as [Tab, string][]).map(([key, label]) => (
+            <button
+              key={key}
+              onClick={() => setTab(key)}
+              className={`-mb-px border-b-2 px-3 py-2.5 text-[13px] font-medium ${
+                tab === key ? "border-indigo-600 text-indigo-600" : "border-transparent text-slate-500 hover:text-slate-900"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
       <div className="mx-auto max-w-5xl px-6 py-8">
         {error && (
           <div className="rounded-xl border border-red-100 bg-red-50 px-4 py-3 text-[13px] text-red-700">{error}</div>
@@ -69,97 +145,647 @@ export function SuperApp() {
           </div>
         )}
 
-        {data && (
-          <>
-            {/* サマリカード */}
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-              <StatCard icon={<Building2 className="h-4 w-4" />} label="自治体" value={data.totals.municipalities} />
-              <StatCard icon={<Users className="h-4 w-4" />} label="隊員" value={data.totals.members} />
-              <StatCard icon={<Users className="h-4 w-4" />} label="役場職員" value={data.totals.managers + data.totals.admins} />
-              <StatCard icon={<ShieldCheck className="h-4 w-4" />} label="運営者(super)" value={data.totals.supers} />
-            </div>
-
-            {/* 自治体一覧 + 操作 */}
-            <div className="mt-8 mb-3 flex items-center justify-between">
-              <h2 className="text-[13px] font-bold text-slate-700">契約自治体</h2>
-              <button
-                onClick={() => setMuniModal(true)}
-                className="inline-flex items-center gap-1 rounded-lg bg-slate-900 px-3 py-1.5 text-[12px] font-bold text-white hover:bg-slate-800"
-              >
-                <Plus className="h-3.5 w-3.5" /> 自治体を追加
-              </button>
-            </div>
-            <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
-              <table className="w-full text-[13px]">
-                <thead className="bg-slate-50 text-[11px] uppercase text-slate-500">
-                  <tr>
-                    <th className="px-4 py-2.5 text-left">自治体</th>
-                    <th className="px-4 py-2.5 text-left">都道府県</th>
-                    <th className="px-4 py-2.5 text-right">隊員</th>
-                    <th className="px-4 py-2.5 text-right">職員</th>
-                    <th className="px-4 py-2.5 text-right">活動記録</th>
-                    <th className="px-4 py-2.5 text-right">操作</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-slate-100">
-                  {data.municipalities.map((m) => (
-                    <tr key={m.id} className="hover:bg-slate-50">
-                      <td className="px-4 py-2.5 font-medium">{m.name}</td>
-                      <td className="px-4 py-2.5 text-slate-500">{m.prefecture}</td>
-                      <td className="px-4 py-2.5 text-right tabular-nums">{m.members}</td>
-                      <td className="px-4 py-2.5 text-right tabular-nums">{m.managers + m.admins}</td>
-                      <td className="px-4 py-2.5 text-right tabular-nums">
-                        <span className="inline-flex items-center gap-1 text-slate-600">
-                          <Activity className="h-3 w-3 text-slate-400" />
-                          {m.activityLogs}
-                        </span>
-                      </td>
-                      <td className="px-4 py-2.5 text-right">
-                        <button
-                          onClick={() => setInviteFor({ id: m.id, name: m.name })}
-                          className="inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-[11px] font-semibold text-slate-700 hover:bg-slate-100"
-                        >
-                          <UserPlus className="h-3 w-3" /> 管理者を招待
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                  {data.municipalities.length === 0 && (
-                    <tr>
-                      <td colSpan={6} className="px-4 py-8 text-center text-slate-400">契約自治体がありません</td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
-          </>
+        {data && tab === "overview" && (
+          <OverviewTab
+            data={data}
+            onAddMuni={() => setMuniModal(true)}
+            onInvite={(m) => setInviteFor(m)}
+            onOpenDetail={openDetail}
+            onOpenContract={setContractId}
+          />
         )}
+        {data && tab === "accounts" && <AccountsTab municipalities={data.municipalities} />}
+        {data && tab === "analytics" && <AnalyticsTab />}
       </div>
 
+      {/* #65 自治体追加モーダル */}
       {muniModal && (
         <MuniModal
           onClose={() => setMuniModal(false)}
-          onCreated={() => { setMuniModal(false); load(); }}
+          onCreated={() => { setMuniModal(false); loadOverview(); }}
         />
       )}
+      {/* #65 管理者招待モーダル */}
       {inviteFor && (
         <InviteModal muni={inviteFor} onClose={() => setInviteFor(null)} />
+      )}
+
+      {/* #66 自治体ドリルダウン スライドオーバー */}
+      {detailId && (
+        <DetailSheet
+          detail={detail}
+          error={detailErr}
+          onClose={() => setDetailId(null)}
+        />
+      )}
+
+      {/* #66 契約モーダル */}
+      {contractId && (
+        <ContractModal
+          municipalityId={contractId}
+          onClose={() => setContractId(null)}
+          onSaved={() => {
+            loadOverview();
+            setContractId(null);
+          }}
+        />
       )}
     </main>
   );
 }
 
-function StatCard({ icon, label, value }: { icon: React.ReactNode; label: string; value: number }) {
+/* ---------------- 概要タブ ---------------- */
+
+function OverviewTab({
+  data,
+  onAddMuni,
+  onInvite,
+  onOpenDetail,
+  onOpenContract,
+}: {
+  data: Overview;
+  onAddMuni: () => void;
+  onInvite: (m: { id: string; name: string }) => void;
+  onOpenDetail: (id: string) => void;
+  onOpenContract: (id: string) => void;
+}) {
   return (
-    <div className="rounded-xl border border-slate-200 bg-white p-4">
-      <div className="flex items-center gap-1.5 text-[11px] text-slate-500">
-        {icon}
-        {label}
+    <>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <StatCard icon={<Building2 className="h-4 w-4" />} label="自治体" value={data.totals.municipalities} />
+        <StatCard icon={<Users className="h-4 w-4" />} label="隊員" value={data.totals.members} />
+        <StatCard icon={<Users className="h-4 w-4" />} label="役場職員" value={data.totals.managers + data.totals.admins} />
+        <StatCard icon={<ShieldCheck className="h-4 w-4" />} label="運営者(super)" value={data.totals.supers} />
       </div>
-      <div className="mt-1 text-2xl font-bold tabular-nums">{value}</div>
+
+      <div className="mt-8 mb-3 flex items-center justify-between">
+        <h2 className="text-[13px] font-bold text-slate-700">契約自治体</h2>
+        <button
+          onClick={onAddMuni}
+          className="inline-flex items-center gap-1 rounded-lg bg-slate-900 px-3 py-1.5 text-[12px] font-bold text-white hover:bg-slate-800"
+        >
+          <Plus className="h-3.5 w-3.5" /> 自治体を追加
+        </button>
+      </div>
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+        <table className="w-full text-[13px]">
+          <thead className="bg-slate-50 text-[11px] uppercase text-slate-500">
+            <tr>
+              <th className="px-4 py-2.5 text-left">自治体</th>
+              <th className="px-4 py-2.5 text-left">都道府県</th>
+              <th className="px-4 py-2.5 text-right">隊員</th>
+              <th className="px-4 py-2.5 text-right">職員</th>
+              <th className="px-4 py-2.5 text-right">活動記録</th>
+              <th className="px-4 py-2.5 text-right">操作</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {data.municipalities.map((m) => (
+              <tr
+                key={m.id}
+                className="cursor-pointer hover:bg-slate-50"
+                onClick={() => onOpenDetail(m.id)}
+              >
+                <td className="px-4 py-2.5 font-medium">{m.name}</td>
+                <td className="px-4 py-2.5 text-slate-500">{m.prefecture}</td>
+                <td className="px-4 py-2.5 text-right tabular-nums">{m.members}</td>
+                <td className="px-4 py-2.5 text-right tabular-nums">{m.managers + m.admins}</td>
+                <td className="px-4 py-2.5 text-right tabular-nums">
+                  <span className="inline-flex items-center gap-1 text-slate-600">
+                    <Activity className="h-3 w-3 text-slate-400" />
+                    {m.activityLogs}
+                  </span>
+                </td>
+                <td className="px-4 py-2.5 text-right">
+                  <div className="inline-flex items-center gap-1.5">
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onInvite({ id: m.id, name: m.name });
+                      }}
+                      className="inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-[11px] font-semibold text-slate-700 hover:bg-slate-100"
+                    >
+                      <UserPlus className="h-3 w-3" /> 管理者を招待
+                    </button>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onOpenContract(m.id);
+                      }}
+                      className="inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-[11px] text-slate-600 hover:bg-slate-100"
+                    >
+                      <FileText className="h-3 w-3" /> 契約
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {data.municipalities.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-4 py-8 text-center text-slate-400">契約自治体がありません</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+/* ---------------- 自治体詳細 スライドオーバー(#66) ---------------- */
+
+function DetailSheet({
+  detail,
+  error,
+  onClose,
+}: {
+  detail: SuperMuniDetail | null;
+  error: string | null;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-40 flex justify-end">
+      <div className="absolute inset-0 bg-slate-900/30" onClick={onClose} />
+      <div className="relative z-50 h-full w-full max-w-xl overflow-y-auto bg-slate-50 shadow-xl">
+        {!detail && !error && (
+          <div className="flex h-40 items-center justify-center gap-2 text-slate-500">
+            <Loader2 className="h-5 w-5 animate-spin" />
+            読み込み中…
+          </div>
+        )}
+        {error && (
+          <div className="m-6 rounded-xl border border-red-100 bg-red-50 px-4 py-3 text-[13px] text-red-700">{error}</div>
+        )}
+        {detail && (
+          <div className="p-6">
+            <div className="mb-6 flex items-start justify-between">
+              <div>
+                <div className="text-[17px] font-bold">{detail.municipality.name}</div>
+                <div className="mt-0.5 text-[12px] text-slate-500">
+                  {detail.municipality.prefecture}・年間予算 {detail.municipality.annualBudget.toLocaleString()} 円
+                </div>
+              </div>
+              <button onClick={onClose} className="text-slate-400 hover:text-slate-900">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <StatCard icon={<Users className="h-4 w-4" />} label="隊員" value={detail.members.length} />
+              <StatCard icon={<Building2 className="h-4 w-4" />} label="職員" value={detail.staff.length} />
+              <StatCard icon={<Activity className="h-4 w-4" />} label="活動記録" value={detail.activity.totalLogs} />
+              <StatCard icon={<ClipboardCheck className="h-4 w-4" />} label="保留承認" value={detail.pendingApprovals.total} />
+            </div>
+
+            {/* 隊員一覧 */}
+            <h3 className="mt-6 mb-2 text-[13px] font-bold text-slate-700">隊員一覧</h3>
+            <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+              <table className="w-full text-[13px]">
+                <thead className="bg-slate-50 text-[11px] uppercase text-slate-500">
+                  <tr>
+                    <th className="px-3 py-2 text-left">名前</th>
+                    <th className="px-3 py-2 text-left">役割</th>
+                    <th className="px-3 py-2 text-left">任期</th>
+                    <th className="px-3 py-2 text-left">着任日</th>
+                    <th className="px-3 py-2 text-left">状態</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {detail.members.map((m) => (
+                    <tr key={m.id}>
+                      <td className="px-3 py-2 font-medium">{m.name}</td>
+                      <td className="px-3 py-2 text-slate-500">{m.role}</td>
+                      <td className="px-3 py-2 text-slate-500">{m.term}</td>
+                      <td className="px-3 py-2 text-slate-500">{m.startedAt}</td>
+                      <td className="px-3 py-2">
+                        <StatusBadge status={m.status} />
+                      </td>
+                    </tr>
+                  ))}
+                  {detail.members.length === 0 && (
+                    <tr><td colSpan={5} className="px-3 py-6 text-center text-slate-400">隊員がいません</td></tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            {/* 職員一覧 */}
+            <h3 className="mt-6 mb-2 text-[13px] font-bold text-slate-700">職員一覧</h3>
+            <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+              <table className="w-full text-[13px]">
+                <thead className="bg-slate-50 text-[11px] uppercase text-slate-500">
+                  <tr>
+                    <th className="px-3 py-2 text-left">名前</th>
+                    <th className="px-3 py-2 text-left">役職</th>
+                    <th className="px-3 py-2 text-left">所属課</th>
+                    <th className="px-3 py-2 text-left">role</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {detail.staff.map((s) => (
+                    <tr key={s.id}>
+                      <td className="px-3 py-2 font-medium">{s.name}</td>
+                      <td className="px-3 py-2 text-slate-500">{s.title}</td>
+                      <td className="px-3 py-2 text-slate-500">{s.dept}</td>
+                      <td className="px-3 py-2 text-slate-500">{s.role}</td>
+                    </tr>
+                  ))}
+                  {detail.staff.length === 0 && (
+                    <tr><td colSpan={4} className="px-3 py-6 text-center text-slate-400">職員がいません</td></tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            {/* 最近の保留承認 */}
+            <h3 className="mt-6 mb-2 text-[13px] font-bold text-slate-700">最近の保留承認</h3>
+            <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+              <ul className="divide-y divide-slate-100">
+                {detail.pendingApprovals.recent.map((a) => (
+                  <li key={a.id} className="flex items-center gap-2 px-4 py-2.5 text-[13px]">
+                    <span className="rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-700">{a.kind}</span>
+                    <span className="text-slate-500">{a.member}</span>
+                    <span className="truncate font-medium">{a.title}</span>
+                  </li>
+                ))}
+                {detail.pendingApprovals.recent.length === 0 && (
+                  <li className="px-4 py-6 text-center text-slate-400">保留中の承認はありません</li>
+                )}
+                {detail.pendingApprovals.total > detail.pendingApprovals.recent.length && (
+                  <li className="px-4 py-2 text-center text-[12px] text-slate-400">
+                    他 {detail.pendingApprovals.total - detail.pendingApprovals.recent.length} 件
+                  </li>
+                )}
+              </ul>
+            </div>
+
+            {/* 活動メタ */}
+            <div className="mt-6 flex gap-6 text-[12px] text-slate-500">
+              <span>今月の活動記録: <span className="font-semibold text-slate-700">{detail.activity.logsThisMonth}</span></span>
+              <span>最終活動日: <span className="font-semibold text-slate-700">{detail.activity.lastActivityDate ?? "—"}</span></span>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
+
+/* ---------------- アカウント管理タブ(#66) ---------------- */
+
+const ROLE_OPTS = ["member", "manager", "admin", "super"];
+const STATUS_OPTS = ["active", "retired", "suspended"];
+
+function AccountsTab({ municipalities }: { municipalities: MuniRow[] }) {
+  const [users, setUsers] = React.useState<SuperUserRow[] | null>(null);
+  const [fMuni, setFMuni] = React.useState("");
+  const [fRole, setFRole] = React.useState("");
+  const [fStatus, setFStatus] = React.useState("");
+  const [err, setErr] = React.useState<string | null>(null);
+
+  const load = React.useCallback(() => {
+    const qs = new URLSearchParams();
+    if (fMuni) qs.set("municipalityId", fMuni);
+    if (fRole) qs.set("role", fRole);
+    if (fStatus) qs.set("status", fStatus);
+    const q = qs.toString();
+    apiGet<SuperUserRow[]>(`/api/super/users${q ? `?${q}` : ""}`)
+      .then(setUsers)
+      .catch(() => setErr("ユーザーの取得に失敗しました"));
+  }, [fMuni, fRole, fStatus]);
+
+  React.useEffect(() => {
+    load();
+  }, [load]);
+
+  async function patch(id: string, body: { role?: string; status?: string; municipalityId?: string }) {
+    try {
+      const updated = await apiPatch<SuperUserRow>(`/api/super/users/${id}`, body);
+      setUsers((prev) => (prev ? prev.map((u) => (u.id === id ? updated : u)) : prev));
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "更新に失敗しました");
+      load(); // 失敗時(自己変更ブロック等)はサーバ状態に戻す
+    }
+  }
+
+  return (
+    <>
+      <div className="mb-4 flex flex-wrap gap-2">
+        <Select value={fMuni} onChange={setFMuni} label="全自治体">
+          {municipalities.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </Select>
+        <Select value={fRole} onChange={setFRole} label="全ロール">
+          {ROLE_OPTS.map((r) => <option key={r} value={r}>{r}</option>)}
+        </Select>
+        <Select value={fStatus} onChange={setFStatus} label="全状態">
+          {STATUS_OPTS.map((s) => <option key={s} value={s}>{s}</option>)}
+        </Select>
+      </div>
+
+      {err && <div className="mb-3 rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-[12px] text-red-700">{err}</div>}
+
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+        <table className="w-full text-[13px]">
+          <thead className="bg-slate-50 text-[11px] uppercase text-slate-500">
+            <tr>
+              <th className="px-3 py-2.5 text-left">氏名</th>
+              <th className="px-3 py-2.5 text-left">メール</th>
+              <th className="px-3 py-2.5 text-left">自治体</th>
+              <th className="px-3 py-2.5 text-left">role</th>
+              <th className="px-3 py-2.5 text-left">status</th>
+              <th className="px-3 py-2.5 text-right">活動記録</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {(users ?? []).map((u) => (
+              <tr key={u.id} className="hover:bg-slate-50">
+                <td className="px-3 py-2 font-medium">{u.name}</td>
+                <td className="px-3 py-2 text-slate-500">{u.email}</td>
+                <td className="px-3 py-2">
+                  <select
+                    value={u.municipalityId ?? ""}
+                    onChange={(e) => patch(u.id, { municipalityId: e.target.value })}
+                    className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-[12px] disabled:opacity-50"
+                  >
+                    <option value="">(未所属)</option>
+                    {municipalities.map((m) => (
+                      <option key={m.id} value={m.id}>{m.name}</option>
+                    ))}
+                  </select>
+                </td>
+                <td className="px-3 py-2">
+                  <select
+                    value={u.role}
+                    onChange={(e) => patch(u.id, { role: e.target.value })}
+                    className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-[12px] disabled:opacity-50"
+                  >
+                    {ROLE_OPTS.map((r) => <option key={r} value={r}>{r}</option>)}
+                  </select>
+                </td>
+                <td className="px-3 py-2">
+                  <select
+                    value={u.status}
+                    onChange={(e) => patch(u.id, { status: e.target.value })}
+                    className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-[12px] disabled:opacity-50"
+                  >
+                    {STATUS_OPTS.map((s) => <option key={s} value={s}>{s}</option>)}
+                  </select>
+                </td>
+                <td className="px-3 py-2 text-right tabular-nums">{u.activityLogs}</td>
+              </tr>
+            ))}
+            {users && users.length === 0 && (
+              <tr><td colSpan={6} className="px-3 py-8 text-center text-slate-400">該当ユーザーがいません</td></tr>
+            )}
+            {!users && !err && (
+              <tr><td colSpan={6} className="px-3 py-8 text-center text-slate-400">読み込み中…</td></tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+/* ---------------- 分析タブ(#66) ---------------- */
+
+function AnalyticsTab() {
+  const [a, setA] = React.useState<SuperAnalytics | null>(null);
+  const [err, setErr] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    apiGet<SuperAnalytics>("/api/super/analytics")
+      .then(setA)
+      .catch(() => setErr("分析データの取得に失敗しました"));
+  }, []);
+
+  if (err) return <div className="rounded-xl border border-red-100 bg-red-50 px-4 py-3 text-[13px] text-red-700">{err}</div>;
+  if (!a) return (
+    <div className="flex items-center gap-2 text-slate-500">
+      <Loader2 className="h-5 w-5 animate-spin" />
+      読み込み中…
+    </div>
+  );
+
+  const diff = a.totals.logsThisMonth - a.totals.logsPrevMonth;
+  const maxTrend = Math.max(1, ...a.trend.map((t) => t.logs));
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <StatCard icon={<TrendingUp className="h-4 w-4" />} label="週あたり日報/人" value={a.totals.logsPerMemberPerWeek} decimals />
+        <StatCard icon={<Activity className="h-4 w-4" />} label="活動記録総数" value={a.totals.activityLogs} />
+        <div className="rounded-xl border border-slate-200 bg-white p-4">
+          <div className="flex items-center gap-1.5 text-[11px] text-slate-500">
+            <Activity className="h-4 w-4" />
+            今月の活動記録
+          </div>
+          <div className="mt-1 flex items-baseline gap-2">
+            <span className="text-2xl font-bold tabular-nums">{a.totals.logsThisMonth}</span>
+            <span className={`inline-flex items-center gap-0.5 text-[11px] font-semibold ${diff >= 0 ? "text-emerald-600" : "text-red-600"}`}>
+              {diff >= 0 ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
+              {diff >= 0 ? "+" : ""}{diff}
+            </span>
+          </div>
+        </div>
+        <StatCard icon={<Users className="h-4 w-4" />} label="隊員数" value={a.totals.members} />
+      </div>
+
+      {/* 直近6ヶ月トレンド */}
+      <h2 className="mt-8 mb-3 text-[13px] font-bold text-slate-700">直近6ヶ月の活動記録</h2>
+      <div className="rounded-xl border border-slate-200 bg-white p-4">
+        <div className="space-y-2">
+          {a.trend.map((t) => (
+            <div key={t.ym} className="flex items-center gap-3 text-[12px]">
+              <span className="w-16 shrink-0 text-slate-500 tabular-nums">{t.ym}</span>
+              <div className="h-3 flex-1 overflow-hidden rounded-full bg-slate-100">
+                <div
+                  className="h-full rounded-full bg-indigo-500"
+                  style={{ width: `${Math.round((t.logs / maxTrend) * 100)}%` }}
+                />
+              </div>
+              <span className="w-10 shrink-0 text-right tabular-nums text-slate-700">{t.logs}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* 自治体別活動量 */}
+      <h2 className="mt-8 mb-3 text-[13px] font-bold text-slate-700">自治体別活動量</h2>
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+        <table className="w-full text-[13px]">
+          <thead className="bg-slate-50 text-[11px] uppercase text-slate-500">
+            <tr>
+              <th className="px-3 py-2.5 text-left">自治体</th>
+              <th className="px-3 py-2.5 text-left">都道府県</th>
+              <th className="px-3 py-2.5 text-right">隊員</th>
+              <th className="px-3 py-2.5 text-right">活動記録</th>
+              <th className="px-3 py-2.5 text-right">今月</th>
+              <th className="px-3 py-2.5 text-right">週/人</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {a.byMunicipality.map((m) => (
+              <tr key={m.id} className="hover:bg-slate-50">
+                <td className="px-3 py-2 font-medium">{m.name}</td>
+                <td className="px-3 py-2 text-slate-500">{m.prefecture}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{m.members}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{m.activityLogs}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{m.logsThisMonth}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{m.logsPerMemberPerWeek.toFixed(1)}</td>
+              </tr>
+            ))}
+            {a.byMunicipality.length === 0 && (
+              <tr><td colSpan={6} className="px-3 py-8 text-center text-slate-400">データがありません</td></tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+/* ---------------- 契約モーダル(#66) ---------------- */
+
+function ContractModal({
+  municipalityId,
+  onClose,
+  onSaved,
+}: {
+  municipalityId: string;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [c, setC] = React.useState<ContractDTO | null>(null);
+  const [err, setErr] = React.useState<string | null>(null);
+  const [saving, setSaving] = React.useState(false);
+
+  React.useEffect(() => {
+    apiGet<ContractDTO>(`/api/super/municipalities/${municipalityId}/contract`)
+      .then(setC)
+      .catch(() => setErr("契約情報の取得に失敗しました"));
+  }, [municipalityId]);
+
+  async function save() {
+    if (!c) return;
+    setSaving(true);
+    setErr(null);
+    try {
+      await apiPatch<ContractDTO>(`/api/super/municipalities/${municipalityId}/contract`, {
+        plan: c.plan,
+        contractStatus: c.contractStatus,
+        annualBudget: c.annualBudget,
+        contractStart: c.contractStart || undefined,
+        contractEnd: c.contractEnd || undefined,
+      });
+      onSaved();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "保存に失敗しました");
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-slate-900/30" onClick={onClose} />
+      <div className="relative z-50 w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow-xl">
+        {!c && !err && (
+          <div className="flex h-32 items-center justify-center gap-2 text-slate-500">
+            <Loader2 className="h-5 w-5 animate-spin" />
+            読み込み中…
+          </div>
+        )}
+        {err && <div className="mb-3 rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-[12px] text-red-700">{err}</div>}
+        {c && (
+          <>
+            <div className="mb-4 flex items-start justify-between">
+              <div className="text-[15px] font-bold">{c.name} の契約</div>
+              <button onClick={onClose} className="text-slate-400 hover:text-slate-900">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <label className="mb-3 block text-[12px] font-medium text-slate-600">
+              プラン
+              <select
+                value={c.plan}
+                onChange={(e) => setC({ ...c, plan: e.target.value as ContractDTO["plan"] })}
+                className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
+              >
+                {(Object.keys(PLAN_LABEL) as ContractDTO["plan"][]).map((p) => (
+                  <option key={p} value={p}>{PLAN_LABEL[p]}</option>
+                ))}
+              </select>
+            </label>
+
+            <label className="mb-3 block text-[12px] font-medium text-slate-600">
+              契約状態
+              <select
+                value={c.contractStatus}
+                onChange={(e) => setC({ ...c, contractStatus: e.target.value as ContractDTO["contractStatus"] })}
+                className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
+              >
+                {(Object.keys(STATUS_LABEL) as ContractDTO["contractStatus"][]).map((s) => (
+                  <option key={s} value={s}>{STATUS_LABEL[s]}</option>
+                ))}
+              </select>
+            </label>
+
+            <label className="mb-3 block text-[12px] font-medium text-slate-600">
+              年間活動費枠(円)
+              <input
+                type="number"
+                value={c.annualBudget}
+                min={0}
+                onChange={(e) => setC({ ...c, annualBudget: Number(e.target.value) })}
+                className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
+              />
+            </label>
+
+            <div className="mb-4 flex gap-3">
+              <label className="flex-1 text-[12px] font-medium text-slate-600">
+                契約開始
+                <input
+                  type="date"
+                  value={c.contractStart ?? ""}
+                  onChange={(e) => setC({ ...c, contractStart: e.target.value })}
+                  className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
+                />
+              </label>
+              <label className="flex-1 text-[12px] font-medium text-slate-600">
+                契約終了
+                <input
+                  type="date"
+                  value={c.contractEnd ?? ""}
+                  onChange={(e) => setC({ ...c, contractEnd: e.target.value })}
+                  className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
+                />
+              </label>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <button onClick={onClose} className="rounded-lg px-3 py-2 text-[13px] text-slate-500 hover:text-slate-900">
+                キャンセル
+              </button>
+              <button
+                onClick={save}
+                disabled={saving}
+                className="inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-4 py-2 text-[13px] font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+              >
+                {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                保存
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ---------------- #65 自治体追加 / 管理者招待モーダル ---------------- */
 
 function Modal({ title, onClose, children }: { title: string; onClose: () => void; children: React.ReactNode }) {
   return (
@@ -263,5 +889,65 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
       <span className="mb-1 block text-[11px] font-bold text-slate-500">{label}</span>
       {children}
     </label>
+  );
+}
+
+/* ---------------- 共通ヘルパー ---------------- */
+
+function StatCard({
+  icon,
+  label,
+  value,
+  decimals,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  decimals?: boolean;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4">
+      <div className="flex items-center gap-1.5 text-[11px] text-slate-500">
+        {icon}
+        {label}
+      </div>
+      <div className="mt-1 text-2xl font-bold tabular-nums">{decimals ? value.toFixed(1) : value}</div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const map: Record<string, string> = {
+    active: "bg-emerald-50 text-emerald-700",
+    retired: "bg-slate-100 text-slate-500",
+    suspended: "bg-red-50 text-red-700",
+  };
+  return (
+    <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${map[status] ?? "bg-slate-100 text-slate-500"}`}>
+      {status}
+    </span>
+  );
+}
+
+function Select({
+  value,
+  onChange,
+  label,
+  children,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-[12px] text-slate-700"
+    >
+      <option value="">{label}</option>
+      {children}
+    </select>
   );
 }

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -12,10 +12,52 @@ import {
   mapVision,
   mapMonthlyCycle,
 } from "@/lib/api/mappers";
-import type { Repos, RouteDTO, HostOrgDTO, LogForAI, ApprovalRaw, GuidelineRow, RouteStepDTO, DailyLogDTO } from "./types";
+import type {
+  Repos,
+  RouteDTO,
+  HostOrgDTO,
+  LogForAI,
+  ApprovalRaw,
+  GuidelineRow,
+  RouteStepDTO,
+  DailyLogDTO,
+  SuperMuniDetail,
+  SuperUserRow,
+  ContractDTO,
+  SuperAnalytics,
+} from "./types";
 
 // SQLite 実装(ローカル / Vercel デモ)。SQL はここに集約し、Route からは追放する。
 const MUNI = "muni_shinonsen";
+
+// 当月 / N ヶ月前の 'YYYY-MM' を返す(ローカル時刻基準)
+function ymOffset(offset: number): string {
+  const d = new Date();
+  d.setDate(1);
+  d.setMonth(d.getMonth() + offset);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+// municipalities の contract_* 専用カラム → ContractDTO に合成
+function buildContract(row: {
+  id: string;
+  name: string;
+  annual_budget: number;
+  contract_plan: string | null;
+  contract_status: string | null;
+  contract_start: string | null;
+  contract_end: string | null;
+}): ContractDTO {
+  return {
+    municipalityId: row.id,
+    name: row.name,
+    plan: (row.contract_plan as ContractDTO["plan"]) ?? "year1",
+    contractStatus: (row.contract_status as ContractDTO["contractStatus"]) ?? "trial",
+    annualBudget: row.annual_budget,
+    contractStart: row.contract_start ?? undefined,
+    contractEnd: row.contract_end ?? undefined,
+  };
+}
 
 function loadRoutes(): RouteDTO[] {
   const routes = all<Record<string, unknown>>(
@@ -115,6 +157,196 @@ export const sqliteRepos: Repos = {
         [token, a.email, "admin", muni?.name ?? "", a.createdBy, expiresAt]
       );
       return { token, expiresAt };
+    },
+
+    async municipalityDetail(municipalityId): Promise<SuperMuniDetail | null> {
+      const m = get<{ id: string; name: string; prefecture: string; annual_budget: number }>(
+        "SELECT id, name, prefecture, annual_budget FROM municipalities WHERE id=?",
+        [municipalityId]
+      );
+      if (!m) return null;
+
+      const members = all<Record<string, unknown>>(
+        "SELECT id, name, role_label, term, started_at, status FROM users WHERE municipality_id=? AND role='member' ORDER BY started_at",
+        [municipalityId]
+      ).map((r) => ({
+        id: r.id as string,
+        name: r.name as string,
+        role: (r.role_label as string) ?? "",
+        term: (r.term as string) ?? "",
+        startedAt: (r.started_at as string) ?? "未設定",
+        status: (r.status as string) ?? "active",
+      }));
+
+      const staff = all<Record<string, unknown>>(
+        "SELECT id, name, title, department, role, email FROM users WHERE municipality_id=? AND role IN ('manager','admin') ORDER BY created_at",
+        [municipalityId]
+      ).map((r) => ({
+        id: r.id as string,
+        name: r.name as string,
+        title: (r.title as string) ?? "職員",
+        dept: (r.department as string) ?? "",
+        role: r.role as "manager" | "admin",
+        email: (r.email as string) ?? "",
+      }));
+
+      const totalLogs = get<{ c: number }>("SELECT COUNT(*) c FROM activity_logs WHERE municipality_id=?", [municipalityId])?.c ?? 0;
+      const logsThisMonth =
+        get<{ c: number }>("SELECT COUNT(*) c FROM activity_logs WHERE municipality_id=? AND log_date LIKE ?", [municipalityId, `${ymOffset(0)}%`])?.c ?? 0;
+      const lastActivityDate =
+        get<{ d: string }>("SELECT MAX(log_date) d FROM activity_logs WHERE municipality_id=?", [municipalityId])?.d ?? null;
+
+      const pendingRows = all<Record<string, unknown>>(
+        "SELECT * FROM approvals WHERE municipality_id=? AND status='pending' ORDER BY created_at",
+        [municipalityId]
+      );
+      const recent = pendingRows.slice(0, 5).map(mapApproval);
+
+      return {
+        municipality: { id: m.id, name: m.name, prefecture: m.prefecture, annualBudget: m.annual_budget },
+        members,
+        staff,
+        activity: { totalLogs, logsThisMonth, lastActivityDate },
+        pendingApprovals: { total: pendingRows.length, recent },
+      };
+    },
+
+    async listUsers(opts): Promise<SuperUserRow[]> {
+      const conds: string[] = [];
+      const args: unknown[] = [];
+      if (opts?.municipalityId) { conds.push("u.municipality_id=?"); args.push(opts.municipalityId); }
+      if (opts?.role) { conds.push("u.role=?"); args.push(opts.role); }
+      if (opts?.status) { conds.push("u.status=?"); args.push(opts.status); }
+      const where = conds.length ? `WHERE ${conds.join(" AND ")}` : "";
+      const rows = all<Record<string, unknown>>(
+        `SELECT u.id, u.name, u.email, u.role, u.status, u.organization_type, u.municipality_id,
+                m.name AS muni_name, u.created_at,
+                (SELECT COUNT(*) FROM activity_logs a WHERE a.user_id=u.id) AS log_count
+         FROM users u LEFT JOIN municipalities m ON m.id=u.municipality_id
+         ${where} ORDER BY u.created_at`,
+        args
+      );
+      return rows.map((r) => ({
+        id: r.id as string,
+        name: r.name as string,
+        email: (r.email as string) ?? "",
+        role: r.role as string,
+        status: (r.status as string) ?? "active",
+        organizationType: (r.organization_type as string) ?? "",
+        municipalityId: (r.municipality_id as string | null) ?? null,
+        municipalityName: (r.muni_name as string | null) ?? "",
+        activityLogs: (r.log_count as number) ?? 0,
+        createdAt: (r.created_at as string) ?? "",
+      }));
+    },
+
+    async updateUser(id, patch): Promise<SuperUserRow | undefined> {
+      run(
+        `UPDATE users SET
+           role=COALESCE(?,role),
+           status=COALESCE(?,status),
+           municipality_id=COALESCE(?,municipality_id)
+         WHERE id=?`,
+        [patch.role ?? null, patch.status ?? null, patch.municipalityId ?? null, id]
+      );
+      return (await sqliteRepos.super.listUsers()).find((u) => u.id === id);
+    },
+
+    async getContract(municipalityId): Promise<ContractDTO | null> {
+      const m = get<{
+        id: string; name: string; annual_budget: number;
+        contract_plan: string | null; contract_status: string | null;
+        contract_start: string | null; contract_end: string | null;
+      }>(
+        "SELECT id, name, annual_budget, contract_plan, contract_status, contract_start, contract_end FROM municipalities WHERE id=?",
+        [municipalityId]
+      );
+      if (!m) return null;
+      return buildContract(m);
+    },
+
+    async updateContract(municipalityId, patch): Promise<ContractDTO | null> {
+      const exists = get<{ id: string }>("SELECT id FROM municipalities WHERE id=?", [municipalityId]);
+      if (!exists) return null;
+      run(
+        `UPDATE municipalities SET
+           contract_plan=COALESCE(?,contract_plan),
+           contract_status=COALESCE(?,contract_status),
+           contract_start=COALESCE(?,contract_start),
+           contract_end=COALESCE(?,contract_end),
+           annual_budget=COALESCE(?,annual_budget)
+         WHERE id=?`,
+        [
+          patch.plan ?? null,
+          patch.contractStatus ?? null,
+          patch.contractStart ?? null,
+          patch.contractEnd ?? null,
+          patch.annualBudget ?? null,
+          municipalityId,
+        ]
+      );
+      const updated = get<{
+        id: string; name: string; annual_budget: number;
+        contract_plan: string | null; contract_status: string | null;
+        contract_start: string | null; contract_end: string | null;
+      }>(
+        "SELECT id, name, annual_budget, contract_plan, contract_status, contract_start, contract_end FROM municipalities WHERE id=?",
+        [municipalityId]
+      )!;
+      return buildContract(updated);
+    },
+
+    async analytics(): Promise<SuperAnalytics> {
+      const munis = all<{ id: string; name: string; prefecture: string }>(
+        "SELECT id, name, prefecture FROM municipalities ORDER BY prefecture, name"
+      );
+      const totalMembers = get<{ c: number }>("SELECT COUNT(*) c FROM users WHERE role='member' AND status='active'")?.c ?? 0;
+      const totalLogs = get<{ c: number }>("SELECT COUNT(*) c FROM activity_logs")?.c ?? 0;
+      const thisYm = ymOffset(0);
+      const prevYm = ymOffset(-1);
+      const logsThisMonth = get<{ c: number }>("SELECT COUNT(*) c FROM activity_logs WHERE log_date LIKE ?", [`${thisYm}%`])?.c ?? 0;
+      const logsPrevMonth = get<{ c: number }>("SELECT COUNT(*) c FROM activity_logs WHERE log_date LIKE ?", [`${prevYm}%`])?.c ?? 0;
+
+      const trend = Array.from({ length: 6 }, (_, i) => {
+        const ym = ymOffset(-(5 - i));
+        const logs = get<{ c: number }>("SELECT COUNT(*) c FROM activity_logs WHERE log_date LIKE ?", [`${ym}%`])?.c ?? 0;
+        return { ym, logs };
+      });
+
+      const byMunicipality = munis.map((m) => {
+        const activityLogs = get<{ c: number }>("SELECT COUNT(*) c FROM activity_logs WHERE municipality_id=?", [m.id])?.c ?? 0;
+        const members = get<{ c: number }>(
+          "SELECT COUNT(*) c FROM users WHERE municipality_id=? AND role='member' AND status='active'",
+          [m.id]
+        )?.c ?? 0;
+        const mThisMonth = get<{ c: number }>(
+          "SELECT COUNT(*) c FROM activity_logs WHERE municipality_id=? AND log_date LIKE ?",
+          [m.id, `${thisYm}%`]
+        )?.c ?? 0;
+        return {
+          id: m.id,
+          name: m.name,
+          prefecture: m.prefecture,
+          members,
+          activityLogs,
+          logsThisMonth: mThisMonth,
+          logsPerMemberPerWeek: Math.round((mThisMonth / Math.max(members, 1) / 4.345) * 10) / 10,
+        };
+      });
+
+      return {
+        generatedAt: new Date().toISOString(),
+        totals: {
+          members: totalMembers,
+          activityLogs: totalLogs,
+          municipalities: munis.length,
+          logsThisMonth,
+          logsPrevMonth,
+          logsPerMemberPerWeek: Math.round((logsThisMonth / Math.max(totalMembers, 1) / 4.345) * 10) / 10,
+        },
+        trend,
+        byMunicipality,
+      };
     },
   },
 

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -25,9 +25,96 @@ import type {
   GuidelineRow,
   RouteStepDTO,
   DailyLogDTO,
+  SuperMuniDetail,
+  SuperUserRow,
+  ContractDTO,
+  SuperAnalytics,
 } from "./types";
 
 const MUNI = "10000000-0000-4000-8000-000000000001";
+
+// 当月 / N ヶ月前の 'YYYY-MM' を返す(ローカル時刻基準)
+function ymOffset(offset: number): string {
+  const d = new Date();
+  d.setDate(1);
+  d.setMonth(d.getMonth() + offset);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+// 'YYYY-MM' → JST 月初・翌月初の ISO 文字列([gte, lt) 範囲)。
+// sqlite 版の log_date(JST 日付文字列)LIKE 'YYYY-MM%' と一致させるための境界。
+function jstMonthRange(ym: string): { gte: string; lt: string } {
+  const [y, m] = ym.split("-").map(Number);
+  const ny = m === 12 ? y + 1 : y;
+  const nm = m === 12 ? 1 : m + 1;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return {
+    gte: `${y}-${pad(m)}-01T00:00:00+09:00`,
+    lt: `${ny}-${pad(nm)}-01T00:00:00+09:00`,
+  };
+}
+
+// activity_logs を month 範囲(+任意の municipality)で count(行は返さない)。
+async function countLogsInMonth(
+  db: ReturnType<typeof supabase>,
+  ym: string,
+  municipalityId?: string,
+): Promise<number> {
+  const { gte, lt } = jstMonthRange(ym);
+  let q = db
+    .from("activity_logs")
+    .select("*", { count: "exact", head: true })
+    .gte("occurred_at", gte)
+    .lt("occurred_at", lt);
+  if (municipalityId) q = q.eq("municipality_id", municipalityId);
+  const { count } = await q;
+  return count ?? 0;
+}
+
+// activity_logs の総数を count(任意の municipality 絞り込み付き)。
+async function countLogsTotal(
+  db: ReturnType<typeof supabase>,
+  municipalityId?: string,
+): Promise<number> {
+  let q = db.from("activity_logs").select("*", { count: "exact", head: true });
+  if (municipalityId) q = q.eq("municipality_id", municipalityId);
+  const { count } = await q;
+  return count ?? 0;
+}
+
+// users の件数を count(role / status / municipality 絞り込み付き)。
+async function countUsers(
+  db: ReturnType<typeof supabase>,
+  filters: { role?: string; status?: string; municipalityId?: string },
+): Promise<number> {
+  let q = db.from("users").select("*", { count: "exact", head: true });
+  if (filters.role) q = q.eq("role", filters.role);
+  if (filters.status) q = q.eq("status", filters.status);
+  if (filters.municipalityId) q = q.eq("municipality_id", filters.municipalityId);
+  const { count } = await q;
+  return count ?? 0;
+}
+
+// municipalities の contract_* 専用カラム → ContractDTO に合成
+function buildContract(row: {
+  id: string;
+  name: string;
+  annual_budget: number;
+  contract_plan: string | null;
+  contract_status: string | null;
+  contract_start: string | null;
+  contract_end: string | null;
+}): ContractDTO {
+  return {
+    municipalityId: row.id,
+    name: row.name,
+    plan: (row.contract_plan as ContractDTO["plan"]) ?? "year1",
+    contractStatus: (row.contract_status as ContractDTO["contractStatus"]) ?? "trial",
+    annualBudget: row.annual_budget,
+    contractStart: row.contract_start ?? undefined,
+    contractEnd: row.contract_end ?? undefined,
+  };
+}
 
 function supabase() {
   return createClient(
@@ -140,6 +227,220 @@ export const supabaseRepos: Repos = {
         expires_at: expiresAt,
       });
       return { token, expiresAt };
+    },
+
+    async municipalityDetail(municipalityId): Promise<SuperMuniDetail | null> {
+      const db = supabase();
+      const { data: m } = await db
+        .from("municipalities")
+        .select("id, name, prefecture, annual_budget")
+        .eq("id", municipalityId)
+        .maybeSingle();
+      if (!m) return null;
+
+      const [
+        { data: memberRows },
+        { data: staffRows },
+        { data: lastLogRows },
+        { data: pendingRows },
+        { count: pendingCount },
+        totalLogs,
+        logsThisMonth,
+      ] = await Promise.all([
+        db.from("users").select("id, name, role_label, term, started_at, status").eq("municipality_id", municipalityId).eq("role", "member").order("started_at").limit(1000),
+        db.from("users").select("id, name, title, department, role, email").eq("municipality_id", municipalityId).in("role", ["manager", "admin"]).order("created_at").limit(1000),
+        db.from("activity_logs").select("occurred_at").eq("municipality_id", municipalityId).order("occurred_at", { ascending: false }).limit(1),
+        db.from("approvals").select("*").eq("municipality_id", municipalityId).eq("status", "pending").order("created_at").limit(5),
+        db.from("approvals").select("*", { count: "exact", head: true }).eq("municipality_id", municipalityId).eq("status", "pending"),
+        countLogsTotal(db, municipalityId),
+        countLogsInMonth(db, ymOffset(0), municipalityId),
+      ]);
+
+      const members = (memberRows ?? []).map((r) => ({
+        id: r.id as string,
+        name: r.name as string,
+        role: (r.role_label as string) ?? "",
+        term: (r.term as string) ?? "",
+        startedAt: (r.started_at as string) ?? "未設定",
+        status: (r.status as string) ?? "active",
+      }));
+      const staff = (staffRows ?? []).map((r) => ({
+        id: r.id as string,
+        name: r.name as string,
+        title: (r.title as string) ?? "職員",
+        dept: (r.department as string) ?? "",
+        role: r.role as "manager" | "admin",
+        email: (r.email as string) ?? "",
+      }));
+
+      const lastLogs = (lastLogRows ?? []) as { occurred_at: string }[];
+      const lastActivityDate = lastLogs.length ? lastLogs[0].occurred_at.slice(0, 10) : null;
+
+      const recent = (pendingRows ?? []).map((r) => mapApproval({
+        ...r,
+        citations: JSON.stringify(r.citations ?? []),
+        detail: JSON.stringify(r.detail ?? {}),
+        steps: JSON.stringify(r.steps ?? []),
+      }));
+
+      return {
+        municipality: { id: m.id, name: m.name, prefecture: m.prefecture, annualBudget: m.annual_budget },
+        members,
+        staff,
+        activity: { totalLogs, logsThisMonth, lastActivityDate },
+        pendingApprovals: { total: pendingCount ?? 0, recent },
+      };
+    },
+
+    async listUsers(opts): Promise<SuperUserRow[]> {
+      const db = supabase();
+      let query = db.from("users").select("id, name, email, role, status, organization_type, municipality_id, created_at").order("created_at").limit(1000);
+      if (opts?.municipalityId) query = query.eq("municipality_id", opts.municipalityId);
+      if (opts?.role) query = query.eq("role", opts.role);
+      if (opts?.status) query = query.eq("status", opts.status);
+      const [{ data: users }, { data: munis }] = await Promise.all([
+        query,
+        db.from("municipalities").select("id, name").limit(1000),
+      ]);
+      const muniName = new Map<string, string>();
+      for (const m of (munis ?? []) as { id: string; name: string }[]) muniName.set(m.id, m.name);
+
+      const userRows = (users ?? []) as Record<string, unknown>[];
+      // 各ユーザーの活動記録数は head count で正確に取得(全件取得は 1000 行上限で頭打ちになるため)。
+      const logCounts = await Promise.all(
+        userRows.map(async (u) => {
+          const { count } = await db
+            .from("activity_logs")
+            .select("*", { count: "exact", head: true })
+            .eq("user_id", u.id as string);
+          return count ?? 0;
+        }),
+      );
+
+      return userRows.map((u, i) => {
+        const mid = (u.municipality_id as string | null) ?? null;
+        return {
+          id: u.id as string,
+          name: u.name as string,
+          email: (u.email as string) ?? "",
+          role: u.role as string,
+          status: (u.status as string) ?? "active",
+          organizationType: (u.organization_type as string) ?? "",
+          municipalityId: mid,
+          municipalityName: mid ? muniName.get(mid) ?? "" : "",
+          activityLogs: logCounts[i],
+          createdAt: (u.created_at as string) ?? "",
+        };
+      });
+    },
+
+    async updateUser(id, patch): Promise<SuperUserRow | undefined> {
+      const upd: Record<string, unknown> = {};
+      if (patch.role !== undefined) upd.role = patch.role;
+      if (patch.status !== undefined) upd.status = patch.status;
+      if (patch.municipalityId !== undefined) upd.municipality_id = patch.municipalityId;
+      if (Object.keys(upd).length) {
+        await supabase().from("users").update(upd).eq("id", id);
+      }
+      return (await supabaseRepos.super.listUsers()).find((u) => u.id === id);
+    },
+
+    async getContract(municipalityId): Promise<ContractDTO | null> {
+      const { data } = await supabase()
+        .from("municipalities")
+        .select("id, name, annual_budget, contract_plan, contract_status, contract_start, contract_end")
+        .eq("id", municipalityId)
+        .maybeSingle();
+      if (!data) return null;
+      return buildContract(data);
+    },
+
+    async updateContract(municipalityId, patch): Promise<ContractDTO | null> {
+      const db = supabase();
+      const { data: cur } = await db
+        .from("municipalities")
+        .select("id")
+        .eq("id", municipalityId)
+        .maybeSingle();
+      if (!cur) return null;
+      const upd: Record<string, unknown> = {};
+      if (patch.plan !== undefined) upd.contract_plan = patch.plan;
+      if (patch.contractStatus !== undefined) upd.contract_status = patch.contractStatus;
+      if (patch.contractStart !== undefined) upd.contract_start = patch.contractStart;
+      if (patch.contractEnd !== undefined) upd.contract_end = patch.contractEnd;
+      if (patch.annualBudget !== undefined) upd.annual_budget = patch.annualBudget;
+      const { data } = await db
+        .from("municipalities")
+        .update(upd)
+        .eq("id", municipalityId)
+        .select("id, name, annual_budget, contract_plan, contract_status, contract_start, contract_end")
+        .single();
+      return buildContract(data!);
+    },
+
+    async analytics(): Promise<SuperAnalytics> {
+      const db = supabase();
+      const thisYm = ymOffset(0);
+      const prevYm = ymOffset(-1);
+
+      // 一覧表示に必要な municipalities 行のみ取得。集計は全て count クエリで正確に出す。
+      const [
+        { data: munis },
+        totalMembers,
+        totalLogs,
+        logsThisMonth,
+        logsPrevMonth,
+        trendCounts,
+      ] = await Promise.all([
+        db.from("municipalities").select("id, name, prefecture").order("prefecture").order("name").limit(1000),
+        countUsers(db, { role: "member", status: "active" }),
+        countLogsTotal(db),
+        countLogsInMonth(db, thisYm),
+        countLogsInMonth(db, prevYm),
+        Promise.all(
+          Array.from({ length: 6 }, (_, i) => ymOffset(-(5 - i))).map((ym) => countLogsInMonth(db, ym)),
+        ),
+      ]);
+
+      const muniRows = (munis ?? []) as { id: string; name: string; prefecture: string }[];
+
+      const trend = Array.from({ length: 6 }, (_, i) => ({
+        ym: ymOffset(-(5 - i)),
+        logs: trendCounts[i],
+      }));
+
+      const byMunicipality = await Promise.all(
+        muniRows.map(async (m) => {
+          const [members, activityLogs, mThisMonth] = await Promise.all([
+            countUsers(db, { role: "member", status: "active", municipalityId: m.id }),
+            countLogsTotal(db, m.id),
+            countLogsInMonth(db, thisYm, m.id),
+          ]);
+          return {
+            id: m.id,
+            name: m.name,
+            prefecture: m.prefecture,
+            members,
+            activityLogs,
+            logsThisMonth: mThisMonth,
+            logsPerMemberPerWeek: Math.round((mThisMonth / Math.max(members, 1) / 4.345) * 10) / 10,
+          };
+        }),
+      );
+
+      return {
+        generatedAt: new Date().toISOString(),
+        totals: {
+          members: totalMembers,
+          activityLogs: totalLogs,
+          municipalities: muniRows.length,
+          logsThisMonth,
+          logsPrevMonth,
+          logsPerMemberPerWeek: Math.round((logsThisMonth / Math.max(totalMembers, 1) / 4.345) * 10) / 10,
+        },
+        trend,
+        byMunicipality,
+      };
     },
   },
 

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -82,6 +82,70 @@ export type SuperOverview = {
   totals: { municipalities: number; members: number; managers: number; admins: number; supers: number };
 };
 
+// 自治体ドリルダウン詳細(super)
+export type SuperMuniDetail = {
+  municipality: { id: string; name: string; prefecture: string; annualBudget: number };
+  members: { id: string; name: string; role: string; term: string; startedAt: string; status: string }[];
+  staff: { id: string; name: string; title: string; dept: string; role: "manager" | "admin"; email: string }[];
+  activity: { totalLogs: number; logsThisMonth: number; lastActivityDate: string | null };
+  pendingApprovals: { total: number; recent: ApprovalDTO[] };
+};
+
+// アカウント/ロール管理(super)
+export type SuperUserRow = {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  status: string;
+  organizationType: string;
+  municipalityId: string | null;
+  municipalityName: string;
+  activityLogs: number;
+  createdAt: string;
+};
+
+// 契約・課金管理(super)。専用カラム(contract_*)に保存。
+export type ContractDTO = {
+  municipalityId: string;
+  name: string;
+  plan: "year1" | "year2" | "year3";
+  contractStatus: "trial" | "active" | "suspended" | "ended";
+  annualBudget: number;
+  contractStart?: string;
+  contractEnd?: string;
+};
+export type ContractPatch = {
+  plan?: ContractDTO["plan"];
+  contractStatus?: ContractDTO["contractStatus"];
+  annualBudget?: number;
+  contractStart?: string;
+  contractEnd?: string;
+};
+
+// 横断 KPI / 分析(super)
+export type SuperAnalytics = {
+  generatedAt: string;
+  totals: {
+    members: number;
+    activityLogs: number;
+    municipalities: number;
+    logsThisMonth: number;
+    logsPrevMonth: number;
+    logsPerMemberPerWeek: number;
+  };
+  trend: { ym: string; logs: number }[]; // 直近6ヶ月
+  byMunicipality: {
+    id: string;
+    name: string;
+    prefecture: string;
+    members: number;
+    activityLogs: number;
+    logsThisMonth: number;
+    logsPerMemberPerWeek: number;
+  }[];
+};
+
 export interface Repos {
   users: {
     count(): Promise<number>;
@@ -94,6 +158,18 @@ export interface Repos {
     createMunicipality(m: { name: string; prefecture: string; annualBudget?: number }): Promise<{ id: string; name: string; prefecture: string }>;
     /** #65: 指定自治体の admin を pre-provision + 招待トークン発行(url は Route 側で付与) */
     createAdminInvite(a: { municipalityId: string; email: string; name: string; createdBy: string }): Promise<{ token: string; expiresAt: string }>;
+    /** #66: 自治体ドリルダウン詳細(隊員・職員・活動・保留承認) */
+    municipalityDetail(municipalityId: string): Promise<SuperMuniDetail | null>;
+    /** #66: 全自治体横断のユーザー一覧 */
+    listUsers(opts?: { municipalityId?: string; role?: string; status?: string }): Promise<SuperUserRow[]>;
+    /** #66: ユーザーの role/status/所属自治体を更新 */
+    updateUser(id: string, patch: { role?: string; status?: string; municipalityId?: string }): Promise<SuperUserRow | undefined>;
+    /** #66: 契約情報の取得 */
+    getContract(municipalityId: string): Promise<ContractDTO | null>;
+    /** #66: 契約情報の部分更新 */
+    updateContract(municipalityId: string, patch: ContractPatch): Promise<ContractDTO | null>;
+    /** #66: 全国横断 KPI */
+    analytics(): Promise<SuperAnalytics>;
   };
   members: {
     list(): Promise<MemberDTO[]>;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -10,6 +10,10 @@ CREATE TABLE IF NOT EXISTS municipalities (
   name TEXT NOT NULL,
   prefecture TEXT NOT NULL,
   annual_budget INTEGER NOT NULL DEFAULT 2000000,
+  contract_plan TEXT,
+  contract_status TEXT,
+  contract_start TEXT,
+  contract_end TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 

--- a/supabase/migrations/20260629_017_municipality_contract.sql
+++ b/supabase/migrations/20260629_017_municipality_contract.sql
@@ -1,0 +1,6 @@
+-- #66: 契約・課金管理。契約情報は municipalities の専用カラムに保存する
+-- (settings JSON は別セッションが別目的で追加中のため衝突回避)。
+ALTER TABLE municipalities ADD COLUMN IF NOT EXISTS contract_plan text;
+ALTER TABLE municipalities ADD COLUMN IF NOT EXISTS contract_status text;
+ALTER TABLE municipalities ADD COLUMN IF NOT EXISTS contract_start text;
+ALTER TABLE municipalities ADD COLUMN IF NOT EXISTS contract_end text;


### PR DESCRIPTION
## 概要
運営者(super)ダッシュボードに4機能を追加。#65(自治体作成・admin招待)と共存。

## 機能
| 機能 | 内容 |
|---|---|
| **自治体ドリルダウン詳細** | 概要タブの自治体行クリック→右スライドシートで隊員・職員・活動メタ・保留承認(recent5) |
| **アカウント/ロール管理** | ユーザー一覧 + role変更・status無効化・所属自治体付替。自己降格/無効化はAPIでブロック |
| **契約・課金管理** | 自治体ごとの契約プラン/状態/活動費枠。`municipalities` 専用カラム `contract_*` |
| **横断KPI/分析** | 週あたり日報/人・活動総数・今月/前月比・直近6ヶ月トレンド・自治体別 |

## 基盤・規約
- `Repos.super` に6メソッド追加(sqlite/supabase **両実装**)、全 super API は `requireSuper` ガード
- 直SQL禁止(Repos経由)を遵守

## 設計判断
- **契約データは専用カラム**(`contract_plan/contract_status/contract_start/contract_end`)。参照実装の `settings` JSON 方式は develop に settings カラムが無く、別作業と衝突するため回避
- **Supabase集計の1000行上限を回避**: analytics / municipalityDetail / listUsers の集計を `count:exact, head:true` 方式に。月境界は JST の `gte/lt` 範囲で sqlite と一致

## 検証
- `npm run typecheck`: クリーン
- `npm run build`: 成功(super ルート全8本生成)
- 批判的レビュー実施 → high 1件(Supabase集計)を修正済

## 既知の課題(本PR範囲外・別Issue推奨)
- `overview()`(#65既存)も同じ1000行上限パターン → 別途修正推奨
- `status='suspended'` の職員が役場側 staff 一覧から消えない(既存 `staff.list` 挙動)

## 実装メモ
本機能は workflow/agent team で設計→実装→レビュー→修正を実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)