### PR TITLE
merge: admin(自治体責任者/予算配分) を develop へ統合(衝突3件解決)

### DIFF
--- a/src/app/admin/_app.tsx
+++ b/src/app/admin/_app.tsx
@@ -14,7 +14,12 @@ import {
   Building2,
   Workflow,
   Trash2,
+  ChevronUp,
+  ChevronDown,
 } from "lucide-react";
+import { BUDGET_CATEGORIES, ANNUAL_BUDGET_TOTAL } from "@/lib/budget";
+
+type BudgetLine = { category: string; amountLimit: number; used: number; remaining: number };
 
 /* ============================================================
    v5 管理者アプリ ─ 検索エンジン型・3 機能
@@ -43,6 +48,8 @@ type Member = {
   role: string;
   startedAt: string;
   term: string;
+  hostOrganizationId?: string;
+  approvalRouteId?: string;
 };
 
 type Staff = {
@@ -80,8 +87,10 @@ type Sheet =
   | { kind: "staff-edit"; staff: Staff | null }
   | { kind: "assign-edit"; staffId: string }
   | { kind: "host-edit"; host: HostOrg | null }
-  | { kind: "route-view"; route: ApprovalRoute }
+  | { kind: "route-edit"; route: ApprovalRoute | null }
   | null;
+
+type RouteDraft = { id?: string; name: string; kind: string; isDefault: boolean; steps: RouteStep[] };
 
 type Ctx = {
   members: Member[];
@@ -96,6 +105,8 @@ type Ctx = {
   setAssignment: (staffId: string, memberIds: string[]) => void | Promise<void>;
   upsertHost: (h: HostOrg) => void | Promise<void>;
   removeHost: (id: string) => void | Promise<void>;
+  upsertRoute: (r: RouteDraft) => void | Promise<void>;
+  removeRoute: (id: string) => void | Promise<void>;
   sheet: Sheet;
   openSheet: (s: Sheet) => void;
 };
@@ -204,6 +215,23 @@ export function AdminApp() {
     removeHost: async (id) => {
       await apiDelete(`/api/host-organizations/${id}`);
       setHosts((hs) => hs.filter((h) => h.id !== id));
+    },
+    upsertRoute: async (r) => {
+      const isExisting = !!r.id && routes.some((x) => x.id === r.id);
+      const saved = isExisting
+        ? await apiPut<ApprovalRoute>("/api/approval-routes", r)
+        : await apiPost<ApprovalRoute>("/api/approval-routes", r);
+      setRoutes((rs) => {
+        const idx = rs.findIndex((x) => x.id === saved.id);
+        if (idx < 0) return [...rs, saved];
+        const copy = [...rs];
+        copy[idx] = saved;
+        return copy;
+      });
+    },
+    removeRoute: async (id) => {
+      await apiDelete(`/api/approval-routes/${id}`);
+      setRoutes((rs) => rs.filter((r) => r.id !== id));
     },
     sheet,
     openSheet: setSheet,
@@ -562,7 +590,7 @@ function HostsTab() {
 function RoutesTab() {
   const { routes, openSheet } = useApp();
   return (
-    <div>
+    <div className="relative">
       <div className="text-center">
         <h1 className="text-3xl font-bold tracking-tight">承認ルート</h1>
         <p className="mt-1 text-[12px] text-slate-500">
@@ -574,7 +602,7 @@ function RoutesTab() {
         {routes.map((r) => (
           <button
             key={r.id}
-            onClick={() => openSheet({ kind: "route-view", route: r })}
+            onClick={() => openSheet({ kind: "route-edit", route: r })}
             className="w-full rounded-xl border border-slate-200 bg-white p-3 text-left hover:border-slate-900 hover:shadow-sm"
           >
             <div className="flex items-center justify-between">
@@ -603,9 +631,14 @@ function RoutesTab() {
           </button>
         ))}
       </div>
-      <p className="mt-4 text-[10px] text-slate-400">
-        PoC では既定 3 ルートのみ管理。隊員ごとのカスタム割当・新規ルート作成は Year 2。
-      </p>
+
+      <button
+        onClick={() => openSheet({ kind: "route-edit", route: null })}
+        className="fixed bottom-10 right-6 z-30 inline-flex h-12 items-center gap-1.5 rounded-full bg-slate-900 px-5 text-[12px] font-bold text-white shadow-lg ring-4 ring-white transition hover:bg-slate-800 active:scale-95"
+      >
+        <Plus className="h-4 w-4" />
+        ルートを追加
+      </button>
     </div>
   );
 }
@@ -671,22 +704,28 @@ function SheetRoot() {
       {sheet.kind === "host-edit" && (
         <HostEditSheet host={sheet.host} onClose={close} />
       )}
-      {sheet.kind === "route-view" && (
-        <RouteViewSheet route={sheet.route} onClose={close} />
+      {sheet.kind === "route-edit" && (
+        <RouteEditSheet route={sheet.route} onClose={close} />
       )}
     </div>
   );
 }
 
 function HostEditSheet({ host, onClose }: { host: HostOrg | null; onClose: () => void }) {
-  const { upsertHost, removeHost } = useApp();
+  const { upsertHost, removeHost, staff } = useApp();
   const isNew = !host;
   const [name, setName] = React.useState(host?.name ?? "");
   const [kind, setKind] = React.useState(host?.kind ?? "");
+  const [contactUserId, setContactUserId] = React.useState(host?.contactUserId ?? "");
 
   const canSave = !!name.trim();
   async function save() {
-    await upsertHost({ id: host?.id ?? `ho_${Date.now()}`, name: name.trim(), kind: kind.trim() || undefined });
+    await upsertHost({
+      id: host?.id ?? `ho_${Date.now()}`,
+      name: name.trim(),
+      kind: kind.trim() || undefined,
+      contactUserId: contactUserId || undefined,
+    });
     onClose();
   }
 
@@ -707,6 +746,20 @@ function HostEditSheet({ host, onClose }: { host: HostOrg | null; onClose: () =>
 
         <Label>種別(任意)</Label>
         <Input value={kind} onChange={setKind} placeholder="例:農業法人 / 観光協会 / NPO" />
+
+        <Label>連絡先ユーザー(任意)</Label>
+        <select
+          value={contactUserId}
+          onChange={(e) => setContactUserId(e.target.value)}
+          className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-[13px] focus:border-slate-900 focus:outline-none"
+        >
+          <option value="">未設定</option>
+          {staff.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name} / {s.dept}
+            </option>
+          ))}
+        </select>
 
         <div className="mt-6 rounded-xl border border-slate-200 bg-slate-50/50 p-3 text-[11px] leading-relaxed text-slate-600">
           受入団体が経費の財布を握っている場合、「複雑」ルート(担当課 → 受入団体 → 企画課)の中間ステップに登場します。
@@ -733,39 +786,176 @@ function HostEditSheet({ host, onClose }: { host: HostOrg | null; onClose: () =>
   );
 }
 
-function RouteViewSheet({ route, onClose }: { route: ApprovalRoute; onClose: () => void }) {
+const APPROVER_TYPES: { value: RouteStep["approverType"]; label: string }[] = [
+  { value: "dept", label: "役場担当課" },
+  { value: "host_org", label: "受入団体" },
+  { value: "admin", label: "企画課" },
+];
+const ROUTE_KINDS = ["経費", "月次報告", "活動相談"];
+
+function RouteEditSheet({ route, onClose }: { route: ApprovalRoute | null; onClose: () => void }) {
+  const { upsertRoute, removeRoute, hosts } = useApp();
+  const isNew = !route;
+  const [name, setName] = React.useState(route?.name ?? "");
+  const [kind, setKind] = React.useState(route?.kind ?? "経費");
+  const [isDefault, setIsDefault] = React.useState(route?.isDefault ?? false);
+  const [steps, setSteps] = React.useState<RouteStep[]>(
+    route?.steps.map((s) => ({ ...s })) ?? [{ stepNo: 1, approverType: "dept", approverLabel: "担当課" }]
+  );
+
+  function updateStep(i: number, patch: Partial<RouteStep>) {
+    setSteps((ss) => ss.map((s, idx) => (idx === i ? { ...s, ...patch } : s)));
+  }
+  function moveStep(i: number, dir: -1 | 1) {
+    setSteps((ss) => {
+      const j = i + dir;
+      if (j < 0 || j >= ss.length) return ss;
+      const copy = [...ss];
+      [copy[i], copy[j]] = [copy[j], copy[i]];
+      return copy;
+    });
+  }
+  function addStep() {
+    setSteps((ss) => [...ss, { stepNo: ss.length + 1, approverType: "admin", approverLabel: "企画課" }]);
+  }
+  function removeStep(i: number) {
+    setSteps((ss) => ss.filter((_, idx) => idx !== i));
+  }
+
+  const canSave = !!name.trim() && steps.length > 0 && steps.every((s) => s.approverLabel.trim());
+
+  async function save() {
+    const normalized = steps.map((s, i) => ({
+      stepNo: i + 1,
+      approverType: s.approverType,
+      approverLabel: s.approverLabel.trim(),
+      department: s.approverType === "dept" ? s.approverLabel.trim() : undefined,
+      hostOrganizationId: s.approverType === "host_org" ? s.hostOrganizationId : undefined,
+    }));
+    await upsertRoute({ id: route?.id, name: name.trim(), kind, isDefault, steps: normalized });
+    onClose();
+  }
+
   return (
     <>
-      <SheetHeader title="承認ルート" onClose={onClose} />
+      <SheetHeader
+        title={isNew ? "承認ルートを追加" : "承認ルートを編集"}
+        onClose={onClose}
+        right={
+          <button onClick={save} disabled={!canSave} className="text-[11px] font-bold text-slate-900 hover:underline disabled:cursor-not-allowed disabled:text-slate-300">
+            保存
+          </button>
+        }
+      />
       <div className="mx-auto w-full max-w-2xl flex-1 overflow-y-auto px-6 py-6">
-        <div className="flex items-center gap-2">
-          <h1 className="text-2xl font-bold tracking-tight">{route.name}</h1>
-          {route.isDefault && (
-            <span className="rounded-full border border-slate-900 bg-slate-900 px-2 py-0.5 text-[10px] font-bold text-white">既定</span>
-          )}
-        </div>
-        <p className="mt-1 text-[12px] text-slate-500">対象: {route.kind} ・ {route.steps.length} ステップ</p>
+        <Label>ルート名</Label>
+        <Input value={name} onChange={setName} placeholder="例:複雑(担当課 → 受入団体 → 企画課)" />
 
-        <Label>承認の流れ</Label>
-        <ol className="mt-2 space-y-2">
-          {route.steps.map((s, i) => (
-            <li key={s.id ?? i} className="flex items-start gap-3 rounded-xl border border-slate-200 bg-white p-3">
-              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-slate-900 text-[12px] font-bold text-white">
-                {s.stepNo}
-              </div>
-              <div className="flex-1">
-                <div className="text-[13px] font-bold text-slate-900">{s.approverLabel}</div>
-                <div className="mt-0.5 text-[10px] text-slate-500">
-                  種別: {s.approverType === "dept" ? "役場担当課" : s.approverType === "host_org" ? "受入団体" : "企画課(全体取りまとめ)"}
+        <Label>対象</Label>
+        <div className="mt-1 flex gap-1.5">
+          {ROUTE_KINDS.map((k) => (
+            <button
+              key={k}
+              onClick={() => setKind(k)}
+              className={`rounded-full border px-3 py-1 text-[12px] font-medium transition ${
+                kind === k ? "border-slate-900 bg-slate-900 text-white" : "border-slate-300 text-slate-600 hover:border-slate-500"
+              }`}
+            >
+              {k}
+            </button>
+          ))}
+        </div>
+
+        <label className="mt-4 flex items-center gap-2 text-[12px] text-slate-700">
+          <input type="checkbox" checked={isDefault} onChange={(e) => setIsDefault(e.target.checked)} className="h-4 w-4" />
+          この対象の既定ルートにする
+        </label>
+
+        <Label>承認ステップ(上から順に承認)</Label>
+        <div className="mt-2 space-y-2">
+          {steps.map((s, i) => (
+            <div key={i} className="rounded-xl border border-slate-200 bg-white p-3">
+              <div className="flex items-center justify-between gap-2">
+                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-slate-900 text-[11px] font-bold text-white">{i + 1}</span>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => moveStep(i, -1)} disabled={i === 0} className="rounded p-1 text-slate-500 hover:bg-slate-100 disabled:opacity-30">
+                    <ChevronUp className="h-4 w-4" />
+                  </button>
+                  <button onClick={() => moveStep(i, 1)} disabled={i === steps.length - 1} className="rounded p-1 text-slate-500 hover:bg-slate-100 disabled:opacity-30">
+                    <ChevronDown className="h-4 w-4" />
+                  </button>
+                  <button onClick={() => removeStep(i)} disabled={steps.length <= 1} className="rounded p-1 text-rose-500 hover:bg-rose-50 disabled:opacity-30">
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
                 </div>
               </div>
-            </li>
-          ))}
-        </ol>
 
-        <div className="mt-6 rounded-xl border border-slate-200 bg-slate-50/50 p-3 text-[11px] leading-relaxed text-slate-600">
-          PoC では既定 3 ルートのみ。隊員ごとの個別ルート・新規作成・ステップ編集は Year 2 で対応します。
+              <div className="mt-2 flex flex-wrap gap-1">
+                {APPROVER_TYPES.map((t) => (
+                  <button
+                    key={t.value}
+                    onClick={() => {
+                      if (t.value === "admin") updateStep(i, { approverType: t.value, approverLabel: s.approverLabel || "企画課", hostOrganizationId: undefined });
+                      else if (t.value === "dept") updateStep(i, { approverType: t.value, hostOrganizationId: undefined });
+                      else updateStep(i, { approverType: t.value });
+                    }}
+                    className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold transition ${
+                      s.approverType === t.value ? "border-slate-900 bg-slate-900 text-white" : "border-slate-300 text-slate-600 hover:border-slate-500"
+                    }`}
+                  >
+                    {t.label}
+                  </button>
+                ))}
+              </div>
+
+              {s.approverType === "host_org" ? (
+                <select
+                  value={s.hostOrganizationId ?? ""}
+                  onChange={(e) => {
+                    const h = hosts.find((x) => x.id === e.target.value);
+                    updateStep(i, { hostOrganizationId: e.target.value || undefined, approverLabel: h?.name ?? s.approverLabel });
+                  }}
+                  className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-2 py-1.5 text-[13px] focus:border-slate-900 focus:outline-none"
+                >
+                  <option value="">受入団体を選択</option>
+                  {hosts.map((h) => (
+                    <option key={h.id} value={h.id}>{h.name}</option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  type="text"
+                  value={s.approverLabel}
+                  onChange={(e) => updateStep(i, { approverLabel: e.target.value })}
+                  placeholder={s.approverType === "dept" ? "課名(例:商工観光課)" : "表示名(例:企画課)"}
+                  className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-2 py-1.5 text-[13px] focus:border-slate-900 focus:outline-none"
+                />
+              )}
+            </div>
+          ))}
         </div>
+
+        <button onClick={addStep} className="mt-2 inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1.5 text-[11px] font-semibold text-slate-700 hover:border-slate-500">
+          <Plus className="h-3.5 w-3.5" />
+          ステップを追加
+        </button>
+
+        {!isNew && route && (
+          <div className="mt-8 border-t border-slate-100 pt-4">
+            <button
+              onClick={async () => {
+                if (confirm(`ルート「${route.name}」を削除しますか?`)) {
+                  await removeRoute(route.id);
+                  onClose();
+                }
+              }}
+              className="inline-flex items-center gap-1 rounded-full border border-rose-300 px-3 py-1.5 text-[11px] font-semibold text-rose-700 hover:bg-rose-50"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              このルートを削除
+            </button>
+          </div>
+        )}
       </div>
     </>
   );
@@ -802,23 +992,47 @@ function MemberEditSheet({
   member: Member | null;
   onClose: () => void;
 }) {
-  const { upsertMember, removeMember } = useApp();
+  const { upsertMember, removeMember, hosts, routes } = useApp();
   const isNew = !member;
   const [name, setName] = React.useState(member?.name ?? "");
   const [role, setRole] = React.useState(member?.role ?? "");
   const [startedAt, setStartedAt] = React.useState(member?.startedAt ?? "");
   const [term, setTerm] = React.useState(member?.term ?? "1 年目");
+  const [hostOrganizationId, setHostOrganizationId] = React.useState(member?.hostOrganizationId ?? "");
+  const [approvalRouteId, setApprovalRouteId] = React.useState(member?.approvalRouteId ?? "");
+  const expenseRoutes = routes.filter((r) => r.kind === "経費");
 
-  const canSave = name.trim() && role.trim();
+  // 費目別予算枠(既存隊員のみ編集可。新規は作成時に既定配分が自動生成される)
+  const [budget, setBudget] = React.useState<BudgetLine[] | null>(null);
+  React.useEffect(() => {
+    if (!member) return;
+    apiGet<BudgetLine[]>(`/api/budgets?userId=${member.id}`)
+      .then(setBudget)
+      .catch(() => setBudget(null));
+  }, [member]);
+  const budgetTotal = (budget ?? []).reduce((s, b) => s + (b.amountLimit || 0), 0);
+  function setLimit(category: string, v: number) {
+    setBudget((b) => (b ?? []).map((x) => (x.category === category ? { ...x, amountLimit: v } : x)));
+  }
 
-  function save() {
-    upsertMember({
+  const canSave = !!(name.trim() && role.trim());
+
+  async function save() {
+    await upsertMember({
       id: member?.id ?? `m${Date.now()}`,
       name: name.trim(),
       role: role.trim(),
       startedAt: startedAt.trim() || "未設定",
       term,
+      hostOrganizationId: hostOrganizationId || undefined,
+      approvalRouteId: approvalRouteId || undefined,
     });
+    if (member && budget) {
+      await apiPut("/api/budgets", {
+        userId: member.id,
+        allocations: budget.map((b) => ({ category: b.category, amountLimit: b.amountLimit })),
+      });
+    }
     onClose();
   }
 
@@ -863,6 +1077,64 @@ function MemberEditSheet({
             </button>
           ))}
         </div>
+
+        <Label>所属受入団体(委託型)</Label>
+        <select
+          value={hostOrganizationId}
+          onChange={(e) => setHostOrganizationId(e.target.value)}
+          className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-[13px] focus:border-slate-900 focus:outline-none"
+        >
+          <option value="">役場直轄(所属団体なし)</option>
+          {hosts.map((h) => (
+            <option key={h.id} value={h.id}>
+              {h.name}
+            </option>
+          ))}
+        </select>
+
+        <Label>承認ルート(経費)</Label>
+        <select
+          value={approvalRouteId}
+          onChange={(e) => setApprovalRouteId(e.target.value)}
+          className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-[13px] focus:border-slate-900 focus:outline-none"
+        >
+          <option value="">既定ルート(未割当)</option>
+          {expenseRoutes.map((r) => (
+            <option key={r.id} value={r.id}>
+              {r.name}（{r.steps.map((s) => s.approverLabel).join(" → ")}）
+            </option>
+          ))}
+        </select>
+
+        {!isNew && budget && (
+          <>
+            <Label>費目別予算枠(年額 / 合計 ¥{budgetTotal.toLocaleString()})</Label>
+            <p className="mt-1 text-[11px] text-slate-500">
+              活動費の費目別上限。費目間の流用はできないため、隊員の計画に合わせて配分します(目安 合計 ¥{ANNUAL_BUDGET_TOTAL.toLocaleString()})。
+            </p>
+            <div className="mt-2 space-y-1.5">
+              {budget.map((b) => (
+                <div key={b.category} className="flex items-center gap-2">
+                  <span className="w-16 shrink-0 text-[12px] text-slate-700">{b.category}</span>
+                  <div className="flex flex-1 items-center gap-1">
+                    <span className="text-[12px] text-slate-400">¥</span>
+                    <input
+                      type="number"
+                      min={0}
+                      step={10000}
+                      value={b.amountLimit}
+                      onChange={(e) => setLimit(b.category, Math.max(0, Number(e.target.value) || 0))}
+                      className="w-full rounded-lg border border-slate-300 bg-white px-2 py-1 text-right text-[13px] tabular-nums focus:border-slate-900 focus:outline-none"
+                    />
+                  </div>
+                  <span className="w-24 shrink-0 text-right text-[10px] text-slate-400">
+                    使用 ¥{b.used.toLocaleString()}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
 
         {!isNew && member && (
           <div className="mt-8 border-t border-slate-100 pt-4">

--- a/src/app/api/admin/invites/route.ts
+++ b/src/app/api/admin/invites/route.ts
@@ -1,5 +1,5 @@
 import { ok, bad, readJson } from "@/lib/api/http";
-import { requireSession } from "@/lib/api/auth";
+import { requireAdmin } from "@/lib/api/auth";
 import { getDb } from "@/lib/db";
 
 export const runtime = "nodejs";
@@ -13,7 +13,7 @@ type CreateBody = {
 
 /** POST /api/admin/invites — 招待トークン発行 */
 export async function POST(req: Request) {
-  const sess = await requireSession();
+  const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
 
   const { email, role = "member", municipalityName = "" } = await readJson<CreateBody>(req);

--- a/src/app/api/approval-routes/[id]/route.ts
+++ b/src/app/api/approval-routes/[id]/route.ts
@@ -1,12 +1,12 @@
 import { ok } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
-import { requireSession } from "@/lib/api/auth";
+import { requireAdmin } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const sess = await requireSession();
+  const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
   const { id } = await params;
   await getRepos().routes.remove(id);

--- a/src/app/api/approval-routes/route.ts
+++ b/src/app/api/approval-routes/route.ts
@@ -1,7 +1,7 @@
 import { ok, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
 import type { RouteStepDTO } from "@/lib/db/repositories/types";
-import { requireSession } from "@/lib/api/auth";
+import { requireAdmin } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -11,10 +11,18 @@ export async function GET() {
 }
 
 type CreateBody = { name: string; kind: string; isDefault?: boolean; steps: RouteStepDTO[] };
+type UpsertBody = CreateBody & { id?: string };
 
 export async function POST(req: Request) {
-  const sess = await requireSession();
+  const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
   const b = await readJson<CreateBody>(req);
   return ok(await getRepos().routes.create(b), 201);
+}
+
+export async function PUT(req: Request) {
+  const sess = await requireAdmin();
+  if (sess instanceof Response) return sess;
+  const b = await readJson<UpsertBody>(req);
+  return ok(await getRepos().routes.upsert(b));
 }

--- a/src/app/api/assignments/route.ts
+++ b/src/app/api/assignments/route.ts
@@ -1,6 +1,6 @@
 import { ok, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
-import { requireSession } from "@/lib/api/auth";
+import { requireAdmin } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -12,7 +12,7 @@ export async function GET() {
 
 // 指定職員の担当隊員を total replace
 export async function PUT(req: Request) {
-  const sess = await requireSession();
+  const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
   const { staffId, memberIds } = await readJson<{ staffId: string; memberIds: string[] }>(req);
   await getRepos().assignments.replace(staffId, memberIds ?? []);

--- a/src/app/api/budgets/route.ts
+++ b/src/app/api/budgets/route.ts
@@ -1,0 +1,31 @@
+import { ok, bad, readJson } from "@/lib/api/http";
+import { getRepos } from "@/lib/db/repositories";
+import { requireAppUser, requireAdmin } from "@/lib/api/auth";
+import { currentFiscalYear } from "@/lib/budget";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** GET /api/budgets?userId=&fiscalYear= — 費目別予算枠サマリ。本人 or admin/super のみ。 */
+export async function GET(req: Request) {
+  const sess = await requireAppUser();
+  if (sess instanceof Response) return sess;
+  const url = new URL(req.url);
+  const userId = url.searchParams.get("userId") ?? sess.userId;
+  const fiscalYear = url.searchParams.get("fiscalYear") ?? currentFiscalYear();
+  const isPrivileged = sess.role === "admin" || sess.role === "super";
+  if (userId !== sess.userId && !isPrivileged) return bad("他の隊員の予算枠は閲覧できません", 403);
+  return ok(await getRepos().budgets.summaryByUser(userId, fiscalYear));
+}
+
+type PutBody = { userId: string; fiscalYear?: string; allocations: { category: string; amountLimit: number }[] };
+
+/** PUT /api/budgets — 隊員の費目別予算枠を全置換(admin のみ)。 */
+export async function PUT(req: Request) {
+  const sess = await requireAdmin();
+  if (sess instanceof Response) return sess;
+  const b = await readJson<PutBody>(req);
+  if (!b.userId || !Array.isArray(b.allocations)) return bad("userId / allocations は必須です");
+  const fiscalYear = b.fiscalYear ?? currentFiscalYear();
+  return ok(await getRepos().budgets.upsert(b.userId, fiscalYear, b.allocations));
+}

--- a/src/app/api/daily-logs/route.ts
+++ b/src/app/api/daily-logs/route.ts
@@ -1,6 +1,6 @@
 import { ok, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
-import { expandRoute } from "@/lib/workflow";
+import { expandRoute, expandAssignedRoute } from "@/lib/workflow";
 import { requireAppUser } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
@@ -80,6 +80,8 @@ export async function POST(req: Request) {
 
   // 経費明細を登録
   const memberName = (await repos.users.nameOf(userId)) ?? "隊員";
+  // ADR-012: 隊員に割り当てられたルートを優先(委託型=団体ステップ含む)。未割当は既定。
+  const assigned = await repos.routes.getForUser(userId);
   for (let i = 0; i < expenses.length; i++) {
     const e = expenses[i];
     const activityLogId = createdActivities[0]?.id;
@@ -94,7 +96,8 @@ export async function POST(req: Request) {
       hasReceipt: !!e.hasReceipt,
       status: "申請中",
     });
-    const { routeName, steps } = expandRoute("経費", "担当課");
+    const { routeName, steps } =
+      assigned && assigned.steps.length ? expandAssignedRoute(assigned) : expandRoute("経費", "担当課");
     await repos.approvals.enqueue({
       muni: MUNI,
       kind: "経費",
@@ -106,6 +109,7 @@ export async function POST(req: Request) {
         kind: "経費",
         purpose: exp.purpose,
         amount: exp.amount,
+        category: exp.category,
         payee: "",
         paidDate: date,
         receipt: e.hasReceipt,

--- a/src/app/api/expenses/route.ts
+++ b/src/app/api/expenses/route.ts
@@ -1,6 +1,6 @@
 import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
-import { expandRoute } from "@/lib/workflow";
+import { expandRoute, expandAssignedRoute } from "@/lib/workflow";
 import { requireAppUser } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
@@ -46,7 +46,10 @@ export async function POST(req: Request) {
 
   // 役場側の承認キューに投入(隊員申請 → 役場が見える、ADR-012)
   const memberName = (await repos.users.nameOf(userId)) ?? "隊員";
-  const { routeName, steps } = expandRoute("経費", "担当課");
+  // ADR-012: 隊員に割り当てられたルートを優先(委託型=団体ステップ含む)。未割当は既定。
+  const assigned = await repos.routes.getForUser(userId);
+  const { routeName, steps } =
+    assigned && assigned.steps.length ? expandAssignedRoute(assigned) : expandRoute("経費", "担当課");
   await repos.approvals.enqueue({
     muni: MUNI,
     kind: "経費",
@@ -54,7 +57,7 @@ export async function POST(req: Request) {
     memberName,
     title: `${b.title} ¥${b.amount.toLocaleString()}`,
     ai: "隊員からの新規経費申請。AI 判定材料は未生成。",
-    detail: { kind: "経費", purpose: b.purpose, amount: b.amount, payee: "", paidDate: "", receipt: false },
+    detail: { kind: "経費", purpose: b.purpose, amount: b.amount, category: created.category, payee: "", paidDate: "", receipt: false },
     routeName,
     steps,
     targetTable: "expenses",

--- a/src/app/api/host-organizations/[id]/route.ts
+++ b/src/app/api/host-organizations/[id]/route.ts
@@ -1,12 +1,12 @@
 import { ok } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
-import { requireSession } from "@/lib/api/auth";
+import { requireAdmin } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const sess = await requireSession();
+  const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
   const { id } = await params;
   await getRepos().hostOrgs.remove(id);

--- a/src/app/api/host-organizations/route.ts
+++ b/src/app/api/host-organizations/route.ts
@@ -1,6 +1,6 @@
 import { ok, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
-import { requireSession } from "@/lib/api/auth";
+import { requireAdmin } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -12,7 +12,7 @@ export async function GET() {
 type Body = { id?: string; name: string; kind?: string; contactUserId?: string };
 
 export async function POST(req: Request) {
-  const sess = await requireSession();
+  const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
   const b = await readJson<Body>(req);
   const saved = await getRepos().hostOrgs.upsert(b);

--- a/src/app/api/members/[id]/route.ts
+++ b/src/app/api/members/[id]/route.ts
@@ -1,13 +1,13 @@
 import { ok } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
-import { requireSession } from "@/lib/api/auth";
+import { requireAdmin } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 // 退任(データは保持し status=retired に)+ 担当割当から外す。
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const sess = await requireSession();
+  const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
   const { id } = await params;
   await getRepos().members.retire(id);

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,6 +1,6 @@
 import { ok, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
-import { requireSession } from "@/lib/api/auth";
+import { requireAdmin } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -9,10 +9,10 @@ export async function GET() {
   return ok(await getRepos().members.list());
 }
 
-type Body = { id?: string; name: string; role: string; startedAt?: string; term?: string };
+type Body = { id?: string; name: string; role: string; startedAt?: string; term?: string; hostOrganizationId?: string | null; approvalRouteId?: string | null };
 
 export async function POST(req: Request) {
-  const sess = await requireSession();
+  const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
   const b = await readJson<Body>(req);
   const saved = await getRepos().members.upsert(b);

--- a/src/app/api/staff/[id]/route.ts
+++ b/src/app/api/staff/[id]/route.ts
@@ -1,12 +1,12 @@
 import { ok } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
-import { requireSession } from "@/lib/api/auth";
+import { requireAdmin } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const sess = await requireSession();
+  const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
   const { id } = await params;
   await getRepos().staff.remove(id);

--- a/src/app/api/staff/route.ts
+++ b/src/app/api/staff/route.ts
@@ -1,6 +1,6 @@
 import { ok, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
-import { requireSession } from "@/lib/api/auth";
+import { requireAdmin } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -12,7 +12,7 @@ export async function GET() {
 type Body = { id?: string; name: string; title?: string; dept: string; email?: string };
 
 export async function POST(req: Request) {
-  const sess = await requireSession();
+  const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
   const b = await readJson<Body>(req);
   const saved = await getRepos().staff.upsert(b);

--- a/src/app/manager/_app.tsx
+++ b/src/app/manager/_app.tsx
@@ -65,6 +65,7 @@ type ExpenseDetail = {
   kind: "経費";
   purpose: string;
   amount: number;
+  category?: string;
   payee: string;
   paidDate: string;
   receipt: boolean;
@@ -94,6 +95,7 @@ type Approval = {
   id: string;
   kind: "経費" | "月次報告" | "活動相談";
   member: string;
+  applicantId?: string;
   title: string;
   ai: string;
   citations: { source: string; quote: string }[];
@@ -979,6 +981,9 @@ function ApprovalDetailSheet({ approval, onClose }: { approval: Approval; onClos
         {approval.detail.kind === "活動相談" && <ConsultDetailView d={approval.detail} />}
         {approval.detail.kind === "月次報告" && <ReportDetailView d={approval.detail} />}
         {approval.detail.kind === "経費" && <ExpenseDetailView d={approval.detail} />}
+        {approval.detail.kind === "経費" && approval.applicantId && approval.detail.category && (
+          <ExpenseBudgetImpact userId={approval.applicantId} category={approval.detail.category} amount={approval.detail.amount} />
+        )}
 
         {/* AI 判定材料 */}
         <Label>AI 判定材料</Label>
@@ -1136,6 +1141,32 @@ function ExpenseDetailView({ d }: { d: ExpenseDetail }) {
           <Receipt className="h-4 w-4 text-slate-400" />
           {d.receipt ? <span className="text-slate-800">添付あり(タップで原本表示)</span> : <span className="text-rose-700">添付なし(差戻し推奨)</span>}
         </div>
+      </div>
+    </>
+  );
+}
+
+// 費目別予算枠への影響(committed=申請中含む。残額がマイナスなら超過)。
+function ExpenseBudgetImpact({ userId, category, amount }: { userId: string; category: string; amount: number }) {
+  void amount;
+  const [line, setLine] = React.useState<{ category: string; amountLimit: number; used: number; remaining: number } | null>(null);
+  React.useEffect(() => {
+    apiGet<{ category: string; amountLimit: number; used: number; remaining: number }[]>(`/api/budgets?userId=${userId}`)
+      .then((rows) => setLine(rows.find((r) => r.category === category) ?? null))
+      .catch(() => {});
+  }, [userId, category]);
+  if (!line) return null;
+  const over = line.remaining < 0;
+  return (
+    <>
+      <Label>予算への影響(費目:{category})</Label>
+      <div className={`mt-1 rounded-xl border p-3 text-[12px] ${over ? "border-rose-200 bg-rose-50 text-rose-700" : "border-slate-200 bg-slate-50/50 text-slate-700"}`}>
+        <div className="flex flex-wrap gap-x-4 gap-y-1 tabular-nums">
+          <span>枠 ¥{line.amountLimit.toLocaleString()}</span>
+          <span>使用(申請含む) ¥{line.used.toLocaleString()}</span>
+          <span className="font-bold">残額 ¥{line.remaining.toLocaleString()}</span>
+        </div>
+        {over && <div className="mt-1 font-semibold">この費目は予算枠を超過しています。費目間の流用はできないため要確認です。</div>}
       </div>
     </>
   );

--- a/src/app/member/_app.tsx
+++ b/src/app/member/_app.tsx
@@ -2031,6 +2031,14 @@ function ExpenseCreateSheet({ onClose }: { onClose: () => void }) {
   const amountNum = parseInt(amount.replace(/[^0-9]/g, ""), 10);
   const canSubmit = !!title.trim() && amountNum > 0 && purpose.trim().length >= 5 && !saving;
 
+  // 費目別予算枠(残額)。流用不可のため、申請前に残額と超過を可視化する。
+  const [budgetLines, setBudgetLines] = React.useState<{ category: string; amountLimit: number; used: number; remaining: number }[]>([]);
+  React.useEffect(() => {
+    apiGet<typeof budgetLines>("/api/budgets").then(setBudgetLines).catch(() => {});
+  }, []);
+  const line = budgetLines.find((b) => b.category === category);
+  const overBudget = !!line && amountNum > 0 && amountNum > line.remaining;
+
   async function submit() {
     if (!canSubmit) return;
     setSaving(true);
@@ -2099,8 +2107,21 @@ function ExpenseCreateSheet({ onClose }: { onClose: () => void }) {
         </div>
         <p className="mt-1 text-[13px] text-slate-400">活動に紐づかない経費(備品・通信費など)もここから申請できます。</p>
 
+        {line && (
+          <p className="mt-2 text-[13px] text-slate-500">
+            「{category}」の残額 <span className={`font-bold tabular-nums ${overBudget ? "text-rose-600" : "text-slate-800"}`}>¥{line.remaining.toLocaleString()}</span>
+            <span className="text-slate-400"> / 枠 ¥{line.amountLimit.toLocaleString()}</span>
+          </p>
+        )}
+
         <Label>金額(円)</Label>
         <input type="text" inputMode="numeric" value={amount} onChange={(e) => setAmount(e.target.value)} placeholder="例:12800" className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-[17px] focus:border-slate-900 focus:outline-none" />
+
+        {overBudget && line && (
+          <div className="mt-2 rounded-xl border border-rose-200 bg-rose-50 p-3 text-[13px] leading-relaxed text-rose-700">
+            「{category}」の残額 ¥{line.remaining.toLocaleString()} を ¥{(amountNum - line.remaining).toLocaleString()} 超えています。費目間の流用はできないため、担当課への相談をおすすめします(申請はできます)。
+          </div>
+        )}
 
         <Label right={
           <ConsultButton

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -30,3 +30,11 @@ export async function requireAppUser(): Promise<{ authId: string; userId: string
   if (!appUser) return bad("このアカウントは未登録です(管理者の招待が必要です)", 403);
   return { authId, userId: appUser.id, role: appUser.role };
 }
+
+/** 管理者(admin)専用ルートの先頭で呼ぶ。admin / super 以外は 403。 */
+export async function requireAdmin(): Promise<{ authId: string; userId: string; role: string } | Response> {
+  const sess = await requireAppUser();
+  if (sess instanceof Response) return sess;
+  if (sess.role !== "admin" && sess.role !== "super") return bad("管理者(admin)権限が必要です", 403);
+  return sess;
+}

--- a/src/lib/api/mappers.ts
+++ b/src/lib/api/mappers.ts
@@ -124,6 +124,7 @@ export function mapApproval(r: Row) {
     id: r.id as string,
     kind: r.kind as "経費" | "月次報告" | "活動相談",
     member: r.member_name as string,
+    applicantId: (r.applicant_id as string | null) ?? undefined,
     title: r.title as string,
     ai: (r.ai as string) ?? "",
     citations: j<{ source: string; quote: string }[]>(r.citations, []),
@@ -155,6 +156,8 @@ export function mapMember(r: Row) {
     role: (r.role_label as string) ?? "",
     startedAt: (r.started_at as string) ?? "未設定",
     term: (r.term as string) ?? "1 年目",
+    hostOrganizationId: (r.host_organization_id as string | null) ?? undefined,
+    approvalRouteId: (r.approval_route_id as string | null) ?? undefined,
   };
 }
 

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -1,0 +1,29 @@
+// 費目別予算枠(活動費 200 万/人)の共有定義。
+// 経費カテゴリ(member 側 EXPENSE_CATEGORIES)と一本化し、admin/member/manager/repo から参照する。
+
+export const BUDGET_CATEGORIES = ["活動費", "旅費", "備品", "消耗品", "通信費", "謝金", "その他"] as const;
+
+// 1 隊員あたりの年額既定配分(合計 2,000,000 = 活動費上限)。admin が後で調整可。
+export const DEFAULT_ALLOCATION: Record<string, number> = {
+  活動費: 800000,
+  旅費: 300000,
+  備品: 300000,
+  消耗品: 200000,
+  通信費: 150000,
+  謝金: 150000,
+  その他: 100000,
+};
+
+export const ANNUAL_BUDGET_TOTAL = 2000000;
+
+/** 現在の年度(4 月始まり)を "YYYY" で返す。例: 2026-06 → "2026"、2026-02 → "2025"。 */
+export function currentFiscalYear(d: Date = new Date()): string {
+  const y = d.getFullYear();
+  const m = d.getMonth() + 1; // 1-12
+  return String(m >= 4 ? y : y - 1);
+}
+
+/** 既定配分を upsert 用の配列に変換 */
+export function defaultAllocationList(): { category: string; amountLimit: number }[] {
+  return BUDGET_CATEGORIES.map((category) => ({ category, amountLimit: DEFAULT_ALLOCATION[category] ?? 0 }));
+}

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -12,10 +12,29 @@ import {
   mapVision,
   mapMonthlyCycle,
 } from "@/lib/api/mappers";
-import type { Repos, RouteDTO, HostOrgDTO, LogForAI, ApprovalRaw, GuidelineRow, RouteStepDTO, DailyLogDTO } from "./types";
+import type { Repos, RouteDTO, HostOrgDTO, LogForAI, ApprovalRaw, GuidelineRow, RouteStepDTO, DailyLogDTO, BudgetLineDTO } from "./types";
+import { BUDGET_CATEGORIES, DEFAULT_ALLOCATION, currentFiscalYear } from "@/lib/budget";
 
 // SQLite 実装(ローカル / Vercel デモ)。SQL はここに集約し、Route からは追放する。
 const MUNI = "muni_shinonsen";
+
+// 年度 "YYYY"(4 月始まり)→ [開始日, 翌年度開始日)。経費の created_at(YYYY-MM-DD…)を辞書順比較で絞る。
+function fyRange(fy: string): [string, string] {
+  const y = Number(fy);
+  return [`${y}-04-01`, `${y + 1}-04-01`];
+}
+
+// 新規隊員に当年度の費目別予算枠(既定配分)を投入(既存があればスキップ)。
+function seedDefaultBudget(userId: string) {
+  const fy = currentFiscalYear();
+  for (const category of BUDGET_CATEGORIES) {
+    const exists = get("SELECT id FROM budget_allocations WHERE user_id=? AND fiscal_year=? AND category=?", [userId, fy, category]);
+    if (exists) continue;
+    run("INSERT INTO budget_allocations (id,municipality_id,user_id,fiscal_year,category,amount_limit) VALUES (?,?,?,?,?,?)", [
+      genId("bud"), MUNI, userId, fy, category, DEFAULT_ALLOCATION[category] ?? 0,
+    ]);
+  }
+}
 
 function loadRoutes(): RouteDTO[] {
   const routes = all<Record<string, unknown>>(
@@ -102,17 +121,19 @@ export const sqliteRepos: Repos = {
     async upsert(m) {
       const existing = m.id ? get("SELECT id FROM users WHERE id=?", [m.id]) : undefined;
       if (existing) {
-        run("UPDATE users SET name=?, role_label=?, started_at=?, term=? WHERE id=?", [
-          m.name, m.role, m.startedAt ?? "未設定", m.term ?? "1 年目", m.id,
+        run("UPDATE users SET name=?, role_label=?, started_at=?, term=?, host_organization_id=?, approval_route_id=? WHERE id=?", [
+          m.name, m.role, m.startedAt ?? "未設定", m.term ?? "1 年目", m.hostOrganizationId ?? null, m.approvalRouteId ?? null, m.id,
         ]);
         return mapMember(all("SELECT * FROM users WHERE id=?", [m.id])[0]);
       }
       const id = m.id ?? genId("m");
       run(
-        `INSERT INTO users (id,municipality_id,organization_type,role,name,email,role_label,term,started_at,status)
-         VALUES (?,?,?,?,?,?,?,?,?,?)`,
-        [id, MUNI, "member", "member", m.name, `${id}@member.example.jp`, m.role, m.term ?? "1 年目", m.startedAt ?? "未設定", "active"]
+        `INSERT INTO users (id,municipality_id,host_organization_id,organization_type,role,name,email,role_label,term,started_at,status,approval_route_id)
+         VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+        [id, MUNI, m.hostOrganizationId ?? null, "member", "member", m.name, `${id}@member.example.jp`, m.role, m.term ?? "1 年目", m.startedAt ?? "未設定", "active", m.approvalRouteId ?? null]
       );
+      // 新規隊員に当年度の費目別予算枠(既定配分)を自動生成
+      seedDefaultBudget(id);
       return mapMember(all("SELECT * FROM users WHERE id=?", [id])[0]);
     },
     async retire(id) {
@@ -198,6 +219,11 @@ export const sqliteRepos: Repos = {
     async list() {
       return loadRoutes();
     },
+    async getForUser(userId) {
+      const u = get<{ approval_route_id?: string }>("SELECT approval_route_id FROM users WHERE id=?", [userId]);
+      if (!u?.approval_route_id) return null;
+      return loadRoutes().find((r) => r.id === u.approval_route_id) ?? null;
+    },
     async create(r) {
       const id = genId("rt");
       run("INSERT INTO approval_routes (id,municipality_id,name,kind,is_default) VALUES (?,?,?,?,?)", [
@@ -212,9 +238,67 @@ export const sqliteRepos: Repos = {
       }
       return loadRoutes().find((x) => x.id === id);
     },
+    async upsert(r) {
+      if (r.id && get("SELECT id FROM approval_routes WHERE id=?", [r.id])) {
+        run("UPDATE approval_routes SET name=?, kind=?, is_default=? WHERE id=?", [
+          r.name, r.kind, r.isDefault ? 1 : 0, r.id,
+        ]);
+        run("DELETE FROM approval_route_steps WHERE route_id=?", [r.id]); // 全置換
+        for (const s of r.steps ?? []) {
+          run(
+            `INSERT INTO approval_route_steps (id,route_id,step_no,approver_type,approver_label,department,host_organization_id)
+             VALUES (?,?,?,?,?,?,?)`,
+            [genId("st"), r.id, s.stepNo, s.approverType, s.approverLabel, s.department ?? null, s.hostOrganizationId ?? null]
+          );
+        }
+        return loadRoutes().find((x) => x.id === r.id);
+      }
+      return sqliteRepos.routes.create(r);
+    },
     async remove(id) {
       run("DELETE FROM approval_route_steps WHERE route_id=?", [id]);
       run("DELETE FROM approval_routes WHERE id=?", [id]);
+    },
+  },
+
+  budgets: {
+    async summaryByUser(userId, fiscalYear) {
+      const allocs = all<{ category: string; amount_limit: number }>(
+        "SELECT category, amount_limit FROM budget_allocations WHERE user_id=? AND fiscal_year=?",
+        [userId, fiscalYear]
+      );
+      const limitMap: Record<string, number> = {};
+      for (const a of allocs) limitMap[a.category] = a.amount_limit;
+      // 使用額 = committed(差戻し以外)を費目別に集計、当年度のみ
+      const [start, end] = fyRange(fiscalYear);
+      const usedRows = all<{ category: string; used: number }>(
+        `SELECT category, COALESCE(SUM(amount_requested),0) used FROM expenses
+         WHERE user_id=? AND status != '差戻し' AND created_at >= ? AND created_at < ? GROUP BY category`,
+        [userId, start, end]
+      );
+      const usedMap: Record<string, number> = {};
+      for (const r of usedRows) usedMap[r.category] = r.used;
+      return BUDGET_CATEGORIES.map((category): BudgetLineDTO => {
+        const amountLimit = limitMap[category] ?? 0;
+        const used = usedMap[category] ?? 0;
+        return { category, amountLimit, used, remaining: amountLimit - used };
+      });
+    },
+    async upsert(userId, fiscalYear, allocations) {
+      for (const a of allocations) {
+        const existing = get<{ id: string }>(
+          "SELECT id FROM budget_allocations WHERE user_id=? AND fiscal_year=? AND category=?",
+          [userId, fiscalYear, a.category]
+        );
+        if (existing) {
+          run("UPDATE budget_allocations SET amount_limit=?, updated_at=datetime('now') WHERE id=?", [a.amountLimit, existing.id]);
+        } else {
+          run("INSERT INTO budget_allocations (id,municipality_id,user_id,fiscal_year,category,amount_limit) VALUES (?,?,?,?,?,?)", [
+            genId("bud"), MUNI, userId, fiscalYear, a.category, a.amountLimit,
+          ]);
+        }
+      }
+      return sqliteRepos.budgets.summaryByUser(userId, fiscalYear);
     },
   },
 

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -25,9 +25,34 @@ import type {
   GuidelineRow,
   RouteStepDTO,
   DailyLogDTO,
+  BudgetLineDTO,
 } from "./types";
+import { BUDGET_CATEGORIES, DEFAULT_ALLOCATION, currentFiscalYear } from "@/lib/budget";
 
 const MUNI = "10000000-0000-4000-8000-000000000001";
+
+// 年度 "YYYY"(4 月始まり)→ [開始日, 翌年度開始日)
+function fyRange(fy: string): [string, string] {
+  const y = Number(fy);
+  return [`${y}-04-01`, `${y + 1}-04-01`];
+}
+
+// 新規隊員に当年度の費目別予算枠(既定配分)を投入(重複は無視)。
+async function seedDefaultBudgetSb(userId: string) {
+  const fy = currentFiscalYear();
+  await supabase()
+    .from("budget_allocations")
+    .upsert(
+      BUDGET_CATEGORIES.map((category) => ({
+        municipality_id: MUNI,
+        user_id: userId,
+        fiscal_year: fy,
+        category,
+        amount_limit: DEFAULT_ALLOCATION[category] ?? 0,
+      })),
+      { onConflict: "user_id,fiscal_year,category", ignoreDuplicates: true }
+    );
+}
 
 function supabase() {
   return createClient(
@@ -124,7 +149,10 @@ export const supabaseRepos: Repos = {
       if (m.id) {
         const { data } = await supabase()
           .from("users")
-          .update({ name: m.name, role_label: m.role, started_at: m.startedAt ?? null, term: m.term ?? "1 年目" })
+          .update({
+            name: m.name, role_label: m.role, started_at: m.startedAt ?? null, term: m.term ?? "1 年目",
+            host_organization_id: m.hostOrganizationId ?? null, approval_route_id: m.approvalRouteId ?? null,
+          })
           .eq("id", m.id)
           .select()
           .single();
@@ -135,6 +163,8 @@ export const supabaseRepos: Repos = {
         .insert({
           municipality_id: MUNI,
           organization_type: "member",
+          host_organization_id: m.hostOrganizationId ?? null,
+          approval_route_id: m.approvalRouteId ?? null,
           role: "member",
           name: m.name,
           role_label: m.role,
@@ -144,6 +174,8 @@ export const supabaseRepos: Repos = {
         })
         .select()
         .single();
+      // 新規隊員に当年度の費目別予算枠(既定配分)を自動生成
+      if (data?.id) await seedDefaultBudgetSb(data.id);
       return mapMember(data!);
     },
     async retire(id) {
@@ -278,6 +310,16 @@ export const supabaseRepos: Repos = {
           })),
       }));
     },
+    async getForUser(userId) {
+      const { data: u } = await supabase()
+        .from("users")
+        .select("approval_route_id")
+        .eq("id", userId)
+        .single();
+      if (!u?.approval_route_id) return null;
+      const list = await supabaseRepos.routes.list();
+      return list.find((r) => r.id === u.approval_route_id) ?? null;
+    },
     async create(r) {
       const { data: route } = await supabase()
         .from("approval_routes")
@@ -300,9 +342,76 @@ export const supabaseRepos: Repos = {
       const list = await supabaseRepos.routes.list();
       return list.find((x) => x.id === route.id);
     },
+    async upsert(r) {
+      if (!r.id) return supabaseRepos.routes.create(r);
+      await supabase()
+        .from("approval_routes")
+        .update({ name: r.name, kind: r.kind, is_default: r.isDefault ?? false })
+        .eq("id", r.id);
+      await supabase().from("approval_route_steps").delete().eq("route_id", r.id); // 全置換
+      if (r.steps?.length) {
+        await supabase().from("approval_route_steps").insert(
+          r.steps.map((s) => ({
+            route_id: r.id,
+            step_no: s.stepNo,
+            approver_type: s.approverType,
+            approver_label: s.approverLabel,
+            department: s.department ?? null,
+            host_organization_id: s.hostOrganizationId ?? null,
+          }))
+        );
+      }
+      const list = await supabaseRepos.routes.list();
+      return list.find((x) => x.id === r.id);
+    },
     async remove(id) {
       await supabase().from("approval_route_steps").delete().eq("route_id", id);
       await supabase().from("approval_routes").delete().eq("id", id);
+    },
+  },
+
+  budgets: {
+    async summaryByUser(userId, fiscalYear) {
+      const { data: allocs } = await supabase()
+        .from("budget_allocations")
+        .select("category, amount_limit")
+        .eq("user_id", userId)
+        .eq("fiscal_year", fiscalYear);
+      const limitMap: Record<string, number> = {};
+      for (const a of allocs ?? []) limitMap[a.category as string] = a.amount_limit as number;
+      const [start, end] = fyRange(fiscalYear);
+      const { data: exps } = await supabase()
+        .from("expenses")
+        .select("category, amount_requested, status, created_at")
+        .eq("user_id", userId)
+        .neq("status", "差戻し")
+        .gte("created_at", start)
+        .lt("created_at", end);
+      const usedMap: Record<string, number> = {};
+      for (const e of exps ?? []) {
+        const cat = (e.category as string) ?? "活動費";
+        usedMap[cat] = (usedMap[cat] ?? 0) + ((e.amount_requested as number) ?? 0);
+      }
+      return BUDGET_CATEGORIES.map((category): BudgetLineDTO => {
+        const amountLimit = limitMap[category] ?? 0;
+        const used = usedMap[category] ?? 0;
+        return { category, amountLimit, used, remaining: amountLimit - used };
+      });
+    },
+    async upsert(userId, fiscalYear, allocations) {
+      await supabase()
+        .from("budget_allocations")
+        .upsert(
+          allocations.map((a) => ({
+            municipality_id: MUNI,
+            user_id: userId,
+            fiscal_year: fiscalYear,
+            category: a.category,
+            amount_limit: a.amountLimit,
+          })),
+          { onConflict: "user_id,fiscal_year,category" }
+        );
+      return supabaseRepos.budgets.summaryByUser(userId, fiscalYear);
     },
   },
 

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -44,6 +44,8 @@ export type RouteStepDTO = {
   hostOrganizationId?: string;
 };
 export type RouteDTO = { id: string; name: string; kind: string; isDefault: boolean; steps: RouteStepDTO[] };
+// 費目別予算枠(1隊員 × 年度 × 費目):枠 / 使用(committed) / 残額
+export type BudgetLineDTO = { category: string; amountLimit: number; used: number; remaining: number };
 
 // AI 月報生成プロンプト用の生ログ
 export type LogForAI = {
@@ -93,7 +95,7 @@ export interface Repos {
   };
   members: {
     list(): Promise<MemberDTO[]>;
-    upsert(m: { id?: string; name: string; role: string; startedAt?: string; term?: string }): Promise<MemberDTO>;
+    upsert(m: { id?: string; name: string; role: string; startedAt?: string; term?: string; hostOrganizationId?: string | null; approvalRouteId?: string | null }): Promise<MemberDTO>;
     retire(id: string): Promise<void>;
   };
   staff: {
@@ -112,8 +114,14 @@ export interface Repos {
   };
   routes: {
     list(): Promise<RouteDTO[]>;
+    getForUser(userId: string): Promise<RouteDTO | null>;
     create(r: { name: string; kind: string; isDefault?: boolean; steps: RouteStepDTO[] }): Promise<RouteDTO | undefined>;
+    upsert(r: { id?: string; name: string; kind: string; isDefault?: boolean; steps: RouteStepDTO[] }): Promise<RouteDTO | undefined>;
     remove(id: string): Promise<void>;
+  };
+  budgets: {
+    summaryByUser(userId: string, fiscalYear: string): Promise<BudgetLineDTO[]>;
+    upsert(userId: string, fiscalYear: string, allocations: { category: string; amountLimit: number }[]): Promise<BudgetLineDTO[]>;
   };
   topics: {
     list(userId: string, kind?: string): Promise<string[]>;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -50,6 +50,19 @@ CREATE TABLE IF NOT EXISTS assignments (
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- 費目別予算枠(隊員 × 年度 × 費目)。活動費 200 万を費目別に配分し、流用不可の早期検知に使う。
+CREATE TABLE IF NOT EXISTS budget_allocations (
+  id TEXT PRIMARY KEY,
+  municipality_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  fiscal_year TEXT NOT NULL,
+  category TEXT NOT NULL,
+  amount_limit INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(user_id, fiscal_year, category)
+);
+
 
 -- ADR-021: 日報(1日のまとめ)。活動記録・経費の上位エンティティ。
 CREATE TABLE IF NOT EXISTS daily_logs (

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -1,4 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
+import { BUDGET_CATEGORIES, DEFAULT_ALLOCATION, currentFiscalYear } from "@/lib/budget";
 
 // 既存モック(member/manager/admin _app.tsx)と同じ初期データを投入。
 // 投入後の画面はモック時代と見た目が変わらない。
@@ -41,6 +42,17 @@ export function seed(db: DatabaseSync) {
     );
     for (const [id, name, role, started, term] of members) {
       insUser.run(id, MUNI, null, "member", "member", name, `${id}@member.example.jp`, role, null, null, term, started, "active");
+    }
+
+    // -- 費目別予算枠(当年度・既定配分 合計 200 万)--
+    const fy = currentFiscalYear();
+    const insBudget = db.prepare(
+      "INSERT INTO budget_allocations (id,municipality_id,user_id,fiscal_year,category,amount_limit) VALUES (?,?,?,?,?,?)"
+    );
+    for (const [mid] of members) {
+      BUDGET_CATEGORIES.forEach((category, ci) => {
+        insBudget.run(`bud_${mid}_${ci}`, MUNI, mid, fy, category, DEFAULT_ALLOCATION[category] ?? 0);
+      });
     }
 
     // -- 役場職員 --

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -1,6 +1,8 @@
 // 多段階承認の展開・遷移ロジック(ADR-012 / ADR-015)。
 // クライアント状態機械をサーバへ移植したもの。
 
+import type { RouteDTO } from "@/lib/db/repositories/types";
+
 export type ApproverType = "dept" | "host_org" | "admin";
 export type StepStatus = "waiting" | "pending" | "approved" | "rejected";
 export type ApprovalStep = {
@@ -36,6 +38,17 @@ export function expandRoute(kind: string, deptLabel = "担当課"): { routeName:
     routeName: "企画課のみ",
     steps: [{ approverType: "admin", approverLabel: "企画課", status: "pending" }],
   };
+}
+
+/** 隊員に割り当てられたルート(RouteDTO)を承認ステップ列に展開(ADR-012 隊員ごと割当)。 */
+export function expandAssignedRoute(route: RouteDTO): { routeName: string; steps: ApprovalStep[] } {
+  const sorted = [...route.steps].sort((a, b) => a.stepNo - b.stepNo);
+  const steps: ApprovalStep[] = sorted.map((s, i) => ({
+    approverType: s.approverType,
+    approverLabel: s.approverLabel,
+    status: i === 0 ? "pending" : "waiting",
+  }));
+  return { routeName: sorted.map((s) => s.approverLabel).join(" → "), steps };
 }
 
 const today = () =>

--- a/supabase/migrations/20260630_024_budget_allocations.sql
+++ b/supabase/migrations/20260630_024_budget_allocations.sql
@@ -1,0 +1,30 @@
+-- 費目別予算枠(隊員 × 年度 × 費目)。活動費 200 万を費目別に配分し、費目間流用の早期検知に使う。
+CREATE TABLE IF NOT EXISTS public.budget_allocations (
+  id              uuid primary key default gen_random_uuid(),
+  municipality_id uuid not null references public.municipalities(id) on delete cascade,
+  user_id         uuid not null references public.users(id) on delete cascade,
+  fiscal_year     text not null,
+  category        text not null,
+  amount_limit    integer not null default 0,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now(),
+  unique(user_id, fiscal_year, category)
+);
+
+CREATE INDEX IF NOT EXISTS idx_budget_alloc_user ON public.budget_allocations(user_id, fiscal_year);
+
+-- RLS(009 と同じ app_* ヘルパーを使用)
+alter table public.budget_allocations enable row level security;
+
+-- 参照:隊員=自分の枠 / 役場=管轄隊員 / 管理者=自治体内
+create policy budget_allocations_select on public.budget_allocations for select using (
+  municipality_id = app_current_municipality_id()
+  and (user_id = app_current_user_id() or app_is_manager_for(user_id) or app_is_admin())
+);
+
+-- 変更:管理者のみ(自治体内)
+create policy budget_allocations_write on public.budget_allocations for all using (
+  app_is_admin() and municipality_id = app_current_municipality_id()
+) with check (
+  app_is_admin() and municipality_id = app_current_municipality_id()
+);


### PR DESCRIPTION
## 概要
`feat/admin-mvp-budget` を develop(super+manager+member入り) へマージ。衝突3ファイルを解決。

## 衝突解決
| ファイル | 解決 |
|---|---|
| auth.ts | develop の `requireSuper` と admin の `requireAdmin` を**両方保持**(admin も requireAppUser ベースで決定Bと整合) |
| sqlite.ts / supabase.ts | develop の super型/contract helper と admin の `BudgetLineDTO`/予算helper(`fyRange`/`seedDefaultBudget`)を**両方残す** |

## admin独自(温存)
予算配分(budget_allocations)・staff・assignments・budget migration

## 検証
- CI(Vercel)で型/ビルド確認
- Workers Builds の fail は既存の無関係エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)