### PR TITLE
fix(admin): 承認ルートの受入団体ステップは団体選択を必須に

### DIFF
--- a/src/app/admin/_app.tsx
+++ b/src/app/admin/_app.tsx
@@ -822,7 +822,12 @@ function RouteEditSheet({ route, onClose }: { route: ApprovalRoute | null; onClo
     setSteps((ss) => ss.filter((_, idx) => idx !== i));
   }
 
-  const canSave = !!name.trim() && steps.length > 0 && steps.every((s) => s.approverLabel.trim());
+  // host_org ステップは受入団体の選択(hostOrganizationId)を必須にする。
+  // 未選択のまま保存すると、承認フローに実体のない受入団体ステップが残ってしまうため。
+  const canSave =
+    !!name.trim() &&
+    steps.length > 0 &&
+    steps.every((s) => (s.approverType === "host_org" ? !!s.hostOrganizationId : !!s.approverLabel.trim()));
 
   async function save() {
     const normalized = steps.map((s, i) => ({


### PR DESCRIPTION
## 背景
admin の承認ルート編集で、ステップ種別を「受入団体(host_org)」に切り替えても受入団体(`hostOrganizationId`)を選択しないまま保存できた。結果、manager 側の多段階承認に**実体のない受入団体ステップ**が残り、承認者が空になりフローが壊れる。

## 変更
- `RouteEditSheet` の `canSave` を修正し、`host_org` ステップは `hostOrganizationId` 必須に（それ以外は従来どおり `approverLabel` 必須）。
- 受入団体未選択時は保存ボタンが無効化される。

## スコープ
- 変更ファイル: `src/app/admin/_app.tsx` のみ（admin スコープ内）。共有ファイル不変更。
- `tsc --noEmit` 0 エラー。

🤖 Generated with [Claude Code](https://claude.com/claude-code)