### PR TITLE
feat(admin): 新規隊員の作成時に費目別予算枠を編集可能に

### DIFF
--- a/src/app/admin/_app.tsx
+++ b/src/app/admin/_app.tsx
@@ -17,7 +17,7 @@ import {
   ChevronUp,
   ChevronDown,
 } from "lucide-react";
-import { BUDGET_CATEGORIES, ANNUAL_BUDGET_TOTAL } from "@/lib/budget";
+import { BUDGET_CATEGORIES, ANNUAL_BUDGET_TOTAL, defaultAllocationList } from "@/lib/budget";
 
 type BudgetLine = { category: string; amountLimit: number; used: number; remaining: number };
 
@@ -98,7 +98,7 @@ type Ctx = {
   assignments: Record<string, string[]>;
   hosts: HostOrg[];
   routes: ApprovalRoute[];
-  upsertMember: (m: Member) => void | Promise<void>;
+  upsertMember: (m: Member) => Promise<Member>;
   removeMember: (id: string) => void | Promise<void>;
   upsertStaff: (s: Staff) => void | Promise<void>;
   removeStaff: (id: string) => void | Promise<void>;
@@ -164,6 +164,7 @@ export function AdminApp() {
         copy[idx] = saved;
         return copy;
       });
+      return saved;
     },
     removeMember: async (id) => {
       await apiDelete(`/api/members/${id}`);
@@ -1002,8 +1003,10 @@ function MemberEditSheet({
   const [approvalRouteId, setApprovalRouteId] = React.useState(member?.approvalRouteId ?? "");
   const expenseRoutes = routes.filter((r) => r.kind === "経費");
 
-  // 費目別予算枠(既存隊員のみ編集可。新規は作成時に既定配分が自動生成される)
-  const [budget, setBudget] = React.useState<BudgetLine[] | null>(null);
+  // 費目別予算枠。既存隊員は現状を取得し、新規隊員は既定配分を初期表示して作成と同時に保存する。
+  const [budget, setBudget] = React.useState<BudgetLine[] | null>(
+    member ? null : defaultAllocationList().map((a) => ({ ...a, used: 0, remaining: a.amountLimit }))
+  );
   React.useEffect(() => {
     if (!member) return;
     apiGet<BudgetLine[]>(`/api/budgets?userId=${member.id}`)
@@ -1018,7 +1021,7 @@ function MemberEditSheet({
   const canSave = !!(name.trim() && role.trim());
 
   async function save() {
-    await upsertMember({
+    const saved = await upsertMember({
       id: member?.id ?? `m${Date.now()}`,
       name: name.trim(),
       role: role.trim(),
@@ -1027,9 +1030,11 @@ function MemberEditSheet({
       hostOrganizationId: hostOrganizationId || undefined,
       approvalRouteId: approvalRouteId || undefined,
     });
-    if (member && budget) {
+    // 新規・既存いずれも、編集した費目別予算枠を保存する(新規は作成後の id に対して反映)。
+    const targetId = member?.id ?? saved?.id;
+    if (targetId && budget) {
       await apiPut("/api/budgets", {
-        userId: member.id,
+        userId: targetId,
         allocations: budget.map((b) => ({ category: b.category, amountLimit: b.amountLimit })),
       });
     }
@@ -1106,7 +1111,7 @@ function MemberEditSheet({
           ))}
         </select>
 
-        {!isNew && budget && (
+        {budget && (
           <>
             <Label>費目別予算枠(年額 / 合計 ¥{budgetTotal.toLocaleString()})</Label>
             <p className="mt-1 text-[11px] text-slate-500">


### PR DESCRIPTION
## 背景
隊員編集シートの費目別予算枠は **既存隊員のみ** 編集可能で、新規追加時は表示されなかった。作成時に既定配分はサーバ側で自動生成されるが（`seedDefaultBudget`）、調整するには一度作成→再オープンが必要だった。

## 変更（`src/app/admin/_app.tsx` のみ）
- 新規隊員でも `defaultAllocationList()`（`@/lib/budget` の既存 helper）を初期表示し、その場で費目配分を編集可能に。
- `upsertMember` が保存済み `Member` を返すよう変更し、`save()` で **作成後の id に対して** 予算枠を `PUT /api/budgets`。
- 既存隊員の挙動は不変。

## スコープ / 検証
- 変更は admin スコープ内のみ（共有ファイル不変更、`budget.ts` は既存 export を import のみ）。
- `tsc --noEmit` 0 エラー。

🤖 Generated with [Claude Code](https://claude.com/claude-code)