### PR TITLE
fix(manager): 役場側APIの認可を厳格化(なりすまし/越境/自己承認を遮断)

### DIFF
--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -1,22 +1,24 @@
-import { ok, readJson } from "@/lib/api/http";
+import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
-import { requireSession } from "@/lib/api/auth";
+import { requireAppUser } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
 
+// お知らせ閲覧はログイン必須(隊員も自町のお知らせを読む)。未認証アクセスを遮断。
 export async function GET(req: Request) {
+  const sess = await requireAppUser();
+  if (sess instanceof Response) return sess;
   const sp = new URL(req.url).searchParams;
   const muni = sp.get("muni") ?? MUNI;
   const kinds = sp.get("kinds")?.split(",").map((k) => k.trim()).filter(Boolean);
   return ok(await getRepos().announcements.list(muni, kinds));
 }
 
+// senderId/senderName は受け付けない(なりすまし防止・サーバ側でセッションから確定)
 type CreateBody = {
-  senderId?: string;
-  senderName?: string;
   kind?: "info" | "rule" | "qa";
   isPinned?: boolean;
   title?: string;
@@ -25,8 +27,24 @@ type CreateBody = {
 };
 
 export async function POST(req: Request) {
-  const sess = await requireSession();
+  const sess = await requireAppUser();
   if (sess instanceof Response) return sess;
+  // 一斉配信は役場職員(manager/admin)のみ。隊員が役場名義で送るのを遮断。
+  if (sess.role !== "manager" && sess.role !== "admin") return bad("お知らせの配信権限がありません", 403);
   const b = await readJson<CreateBody>(req);
-  return ok(await getRepos().announcements.create(b), 201);
+  if (!b.body?.trim()) return bad("本文が必要です");
+  const repos = getRepos();
+  const senderName = (await repos.users.nameOf(sess.userId)) ?? "役場";
+  return ok(
+    await repos.announcements.create({
+      senderId: sess.userId,
+      senderName,
+      kind: b.kind,
+      isPinned: b.isPinned,
+      title: b.title,
+      body: b.body,
+      targets: b.targets,
+    }),
+    201
+  );
 }

--- a/src/app/api/approval-routes/route.ts
+++ b/src/app/api/approval-routes/route.ts
@@ -1,12 +1,16 @@
-import { ok, readJson } from "@/lib/api/http";
+import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
 import type { RouteStepDTO } from "@/lib/db/repositories/types";
-import { requireAdmin } from "@/lib/api/auth";
+import { requireAdmin, requireAppUser } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+// 承認ルート構成は役場職員(manager/admin)のみ閲覧可。未認証アクセスを遮断。
 export async function GET() {
+  const sess = await requireAppUser();
+  if (sess instanceof Response) return sess;
+  if (sess.role !== "manager" && sess.role !== "admin") return bad("権限がありません", 403);
   return ok(await getRepos().routes.list());
 }
 

--- a/src/app/api/approvals/[id]/decide/route.ts
+++ b/src/app/api/approvals/[id]/decide/route.ts
@@ -1,7 +1,7 @@
 import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
 import { applyApprove, applyReject, type ApprovalStep } from "@/lib/workflow";
-import { requireSession } from "@/lib/api/auth";
+import { requireAppUser } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -9,8 +9,10 @@ export const dynamic = "force-dynamic";
 type Body = { action: "approve" | "reject"; comment?: string };
 
 export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const sess = await requireSession();
+  const sess = await requireAppUser();
   if (sess instanceof Response) return sess;
+  // 承認/差戻しは役場職員(manager/admin)のみ。隊員の自己承認・無権限承認を遮断。
+  if (sess.role !== "manager" && sess.role !== "admin") return bad("承認権限がありません", 403);
   const { id } = await params;
   const b = await readJson<Body>(req);
   const repos = getRepos();

--- a/src/app/api/approvals/route.ts
+++ b/src/app/api/approvals/route.ts
@@ -1,5 +1,6 @@
-import { ok } from "@/lib/api/http";
+import { ok, bad } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
+import { requireAppUser } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -7,7 +8,11 @@ export const dynamic = "force-dynamic";
 const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
 
 // 進行中(pending)の承認のみ返す。完了/差戻しはキューから外れる。
+// 承認キューは役場職員(manager/admin)のみ閲覧可。未認証アクセスを遮断。
 export async function GET(req: Request) {
+  const sess = await requireAppUser();
+  if (sess instanceof Response) return sess;
+  if (sess.role !== "manager" && sess.role !== "admin") return bad("権限がありません", 403);
   const muni = new URL(req.url).searchParams.get("muni") ?? MUNI;
   return ok(await getRepos().approvals.listPending(muni));
 }

--- a/src/app/api/monthly-reports/route.ts
+++ b/src/app/api/monthly-reports/route.ts
@@ -1,13 +1,12 @@
 import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
 import { expandRoute } from "@/lib/workflow";
-import { requireAppUser, requireSession } from "@/lib/api/auth";
+import { requireAppUser } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
-const DEFAULT_USER = process.env.NEXT_PUBLIC_DEMO_MEMBER_ID ?? "a1000000-0000-4000-8000-000000000001";
 
 export async function GET() {
   const sess = await requireAppUser();
@@ -15,18 +14,19 @@ export async function GET() {
   return ok(await getRepos().monthlyReports.listByUser(sess.userId));
 }
 
-type SubmitBody = { userId?: string; ym: string; markdown: string; plan?: string };
+type SubmitBody = { ym: string; markdown: string; plan?: string };
 
 /** POST /api/monthly-reports — 月報を役場に提出(永続化 + 承認キュー投入) */
 export async function POST(req: Request) {
-  const sess = await requireSession();
+  const sess = await requireAppUser();
   if (sess instanceof Response) return sess;
   const b = await readJson<SubmitBody>(req);
   if (!b.ym || !/^\d{4}-\d{2}$/.test(b.ym)) return bad("ym(YYYY-MM)が必要です");
   if (!b.markdown?.trim()) return bad("月報本文が空です");
 
   const repos = getRepos();
-  const userId = b.userId ?? DEFAULT_USER;
+  // なりすまし防止: 提出者はセッション本人に固定(body の userId は受け付けない)
+  const userId = sess.userId;
   const report = await repos.monthlyReports.submit({ userId, ym: b.ym, markdown: b.markdown.trim(), plan: b.plan?.trim() });
 
   // 役場側の承認キューに投入(月次報告 ルート)


### PR DESCRIPTION
## 概要
役場側 API の認可崩れ（H4・セキュリティ）を修正。CLAUDE.md MUST「厳格な権限分離」に直結。

## 背景（不具合）
- `approvals/[id]/decide` が `requireSession()` のみ＝**隊員の自己承認・無権限/越境ユーザーの任意承認**が可能。
- `monthly-reports` POST が `body.userId` を信用＝**他人名義で月報提出（なりすまし）**。
- `approvals` / `announcements` / `approval-routes` の GET が**未認証**で `?muni=` 任せ＝横断情報開示。
- `announcements` POST が `requireSession` のみ＋送信者 body 任せ＝**隊員が役場名義で一斉送信**。

## 変更（許可域＝src/app/api の対象4ルートのみ）
- **decide**: `requireAppUser` + `role ∈ {manager,admin}` 403 ゲート。
- **monthly-reports POST**: 提出者を `sess.userId` に固定、`SubmitBody.userId` 削除。
- **approvals GET / approval-routes GET**: `requireAppUser` + manager/admin 限定。
- **announcements GET**: ログイン必須（隊員も自町お知らせ閲覧可）。
- **announcements POST**: manager/admin 限定 + `senderId/senderName` をサーバ側で確定（なりすまし排除）+ 本文未指定の 500 回避。

## 制約遵守
- 編集は許可域のみ。**共有ファイル（repositories/schema/auth/mappers/migrations）は無改修**、既存ヘルパ（`requireAppUser`/`requireAdmin`/`users.nameOf`）を流用。
- 1トピック1コミット（`d92410d`）。

## 検証
- `tsc --noEmit` ✅ / `next build` ✅（develop ベース・worktree）。

## 本PRに含めない（別トピック）
- 「現ステップ担当者本人照合・decidedBy 記録・muni 越境遮断」→ 承認担当者機能（共有DB列）で別途。
- H1 月報グリッド / H2 月報詳細クラッシュ / H3 担当隊員join / H5 MUNI二重定義・既読率 → 別トピック（一部は共有域で事前報告要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)