### PR TITLE
fix(admin): 招待トークンを Repos 経由に統一し Supabase 対応

### DIFF
--- a/src/app/api/admin/invites/[token]/route.ts
+++ b/src/app/api/admin/invites/[token]/route.ts
@@ -1,41 +1,28 @@
 import { ok, bad } from "@/lib/api/http";
-import { getDb } from "@/lib/db";
+import { getRepos } from "@/lib/db/repositories";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-type TokenRow = {
-  token: string;
-  email: string | null;
-  role: string;
-  municipality_name: string;
-  expires_at: string;
-  used_at: string | null;
-};
-
 /** GET /api/admin/invites/[token] — トークン検証(signup ページが呼ぶ) */
 export async function GET(_req: Request, { params }: { params: Promise<{ token: string }> }) {
   const { token } = await params;
-  const row = getDb()
-    .prepare("SELECT * FROM invite_tokens WHERE token=?")
-    .get(token) as TokenRow | undefined;
+  const row = await getRepos().invites.findByToken(token);
 
   if (!row) return bad("招待リンクが無効です", 404);
-  if (row.used_at) return bad("この招待リンクはすでに使用されています", 410);
-  if (new Date(row.expires_at) < new Date()) return bad("招待リンクの有効期限が切れています", 410);
+  if (row.usedAt) return bad("この招待リンクはすでに使用されています", 410);
+  if (new Date(row.expiresAt) < new Date()) return bad("招待リンクの有効期限が切れています", 410);
 
   return ok({
     email: row.email,
     role: row.role,
-    municipalityName: row.municipality_name,
+    municipalityName: row.municipalityName,
   });
 }
 
 /** PATCH /api/admin/invites/[token] — 使用済みマーク(signup 完了時に呼ぶ) */
 export async function PATCH(_req: Request, { params }: { params: Promise<{ token: string }> }) {
   const { token } = await params;
-  getDb()
-    .prepare("UPDATE invite_tokens SET used_at=datetime('now') WHERE token=? AND used_at IS NULL")
-    .run(token);
+  await getRepos().invites.markUsed(token);
   return ok({ ok: true });
 }

--- a/src/app/api/admin/invites/route.ts
+++ b/src/app/api/admin/invites/route.ts
@@ -1,6 +1,6 @@
 import { ok, bad, readJson } from "@/lib/api/http";
 import { requireAdmin } from "@/lib/api/auth";
-import { getDb } from "@/lib/db";
+import { getRepos } from "@/lib/db/repositories";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -18,19 +18,15 @@ export async function POST(req: Request) {
 
   const { email, role = "member", municipalityName = "" } = await readJson<CreateBody>(req);
 
-  // ランダムトークン生成
-  const token = Array.from(crypto.getRandomValues(new Uint8Array(24)))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-
-  // 7日間有効
-  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
-
+  let token: string;
+  let expiresAt: string;
   try {
-    getDb().prepare(
-      `INSERT INTO invite_tokens (token, email, role, municipality_name, expires_at)
-       VALUES (?, ?, ?, ?, ?)`
-    ).run(token, email ?? null, role, municipalityName, expiresAt);
+    ({ token, expiresAt } = await getRepos().invites.create({
+      email: email?.trim() || null,
+      role,
+      municipalityName,
+      createdBy: sess.userId,
+    }));
   } catch {
     return bad("DB error", 500);
   }

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -558,6 +558,42 @@ export const sqliteRepos: Repos = {
     },
   },
 
+  invites: {
+    async create({ email, role, municipalityName, createdBy }) {
+      const token = Array.from(crypto.getRandomValues(new Uint8Array(24)))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+      run(
+        "INSERT INTO invite_tokens (token,email,role,municipality_name,created_by,expires_at) VALUES (?,?,?,?,?,?)",
+        [token, email, role, municipalityName, createdBy, expiresAt]
+      );
+      return { token, expiresAt };
+    },
+    async findByToken(token) {
+      const r = get<{
+        token: string;
+        email: string | null;
+        role: string;
+        municipality_name: string;
+        expires_at: string;
+        used_at: string | null;
+      }>("SELECT * FROM invite_tokens WHERE token=?", [token]);
+      if (!r) return null;
+      return {
+        token: r.token,
+        email: r.email,
+        role: r.role,
+        municipalityName: r.municipality_name,
+        expiresAt: r.expires_at,
+        usedAt: r.used_at,
+      };
+    },
+    async markUsed(token) {
+      run("UPDATE invite_tokens SET used_at=datetime('now') WHERE token=? AND used_at IS NULL", [token]);
+    },
+  },
+
   topics: {
     async list(userId, kind = "topic") {
       const col = kind === "type" ? "activity_type" : "topic";

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -749,6 +749,47 @@ export const supabaseRepos: Repos = {
     },
   },
 
+  invites: {
+    async create({ email, role, municipalityName, createdBy }) {
+      const token = Array.from(crypto.getRandomValues(new Uint8Array(24)))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+      await supabase().from("invite_tokens").insert({
+        token,
+        email,
+        role,
+        municipality_name: municipalityName,
+        created_by: createdBy,
+        expires_at: expiresAt,
+      });
+      return { token, expiresAt };
+    },
+    async findByToken(token) {
+      const { data } = await supabase()
+        .from("invite_tokens")
+        .select("token, email, role, municipality_name, expires_at, used_at")
+        .eq("token", token)
+        .maybeSingle();
+      if (!data) return null;
+      return {
+        token: data.token as string,
+        email: (data.email as string | null) ?? null,
+        role: data.role as string,
+        municipalityName: data.municipality_name as string,
+        expiresAt: data.expires_at as string,
+        usedAt: (data.used_at as string | null) ?? null,
+      };
+    },
+    async markUsed(token) {
+      await supabase()
+        .from("invite_tokens")
+        .update({ used_at: new Date().toISOString() })
+        .eq("token", token)
+        .is("used_at", null);
+    },
+  },
+
   topics: {
     async list(userId, kind = "topic") {
       const col = kind === "type" ? "activity_type" : "topic";

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -47,6 +47,16 @@ export type RouteDTO = { id: string; name: string; kind: string; isDefault: bool
 // 費目別予算枠(1隊員 × 年度 × 費目):枠 / 使用(committed) / 残額
 export type BudgetLineDTO = { category: string; amountLimit: number; used: number; remaining: number };
 
+// 招待トークン(#63)。used/expired の HTTP 判定は route 側で行うため生に近い形で返す。
+export type InviteRow = {
+  token: string;
+  email: string | null;
+  role: string;
+  municipalityName: string;
+  expiresAt: string;
+  usedAt: string | null;
+};
+
 // AI 月報生成プロンプト用の生ログ
 export type LogForAI = {
   activity_type: string;
@@ -202,6 +212,13 @@ export interface Repos {
   budgets: {
     summaryByUser(userId: string, fiscalYear: string): Promise<BudgetLineDTO[]>;
     upsert(userId: string, fiscalYear: string, allocations: { category: string; amountLimit: number }[]): Promise<BudgetLineDTO[]>;
+  };
+  invites: {
+    /** トークンと 7 日有効期限を採番して発行する */
+    create(i: { email: string | null; role: string; municipalityName: string; createdBy: string }): Promise<{ token: string; expiresAt: string }>;
+    findByToken(token: string): Promise<InviteRow | null>;
+    /** used_at が未設定のときだけ使用済みにする */
+    markUsed(token: string): Promise<void>;
   };
   topics: {
     list(userId: string, kind?: string): Promise<string[]>;


### PR DESCRIPTION
## 背景
admin の招待フロー（発行/検証/使用済みマーク）が `getDb()`（`node:sqlite` 専用）を直叩きしており、`DB_PROVIDER=supabase`（本番想定）では**招待機能が丸ごと動作しない**。リポジトリパターン（ADR）から外れた唯一の経路だった。

## 変更
**Repos に `invites` 名前空間を追加（追加のみ・既存挙動不変）**
- `src/lib/db/repositories/types.ts`: `InviteRow` 型 ＋ `invites { create / findByToken / markUsed }` を追加
- `src/lib/db/repositories/sqlite.ts`: `invites` 実装を追加
- `src/lib/db/repositories/supabase.ts`: `invites` 実装を追加

**ルートを repo 経由に統一（admin スコープ内）**
- `POST /api/admin/invites`: `getRepos().invites.create()` へ。`created_by` を発行管理者の `userId` で記録（従来は未設定）
- `GET/PATCH /api/admin/invites/[token]`: `findByToken()` / `markUsed()` へ。used/expired の HTTP 判定（404/410）と認証なし（signup が pre-login で呼ぶ）は維持

## 補足
- `invite_tokens` テーブルは **sqlite・Supabase 両方に既存**（`schema.ts` / `supabase/migrations/20260623_022_invite_tokens.sql`）→ **マイグレーション不要**。
- 各ルートの**外部レスポンス形状は不変**（signup ページの契約を壊さない）。
- トークン生成・7日有効期限は repo に集約（supabase の super フローと同一ロジック）。

## スコープ / 検証
- 共有ファイル3点は**追加のみ**（事前設計を共有し承認済み）。
- `tsc --noEmit` 0 エラー（sqlite/supabase 両実装がインターフェースを満たすことを確認）。
- `#3`（招待の自治体フリーテキスト/admin 自由発行）は本 PR の対象外（別関心事）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)