### PR TITLE
fix(manager): 月報の実データ表示を修正(グリッド状態/詳細クラッシュ)

### DIFF
--- a/src/app/api/monthly-reports/route.ts
+++ b/src/app/api/monthly-reports/route.ts
@@ -9,10 +9,17 @@ export const dynamic = "force-dynamic";
 const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
 const DEFAULT_USER = process.env.NEXT_PUBLIC_DEMO_MEMBER_ID ?? "a1000000-0000-4000-8000-000000000001";
 
-export async function GET() {
+export async function GET(req: Request) {
   const sess = await requireAppUser();
   if (sess instanceof Response) return sess;
-  return ok(await getRepos().monthlyReports.listByUser(sess.userId));
+  // 既定は本人。役場職員(manager/admin)は ?userId で担当隊員の月報を閲覧可。
+  let targetUserId = sess.userId;
+  const qUserId = new URL(req.url).searchParams.get("userId");
+  if (qUserId && qUserId !== sess.userId) {
+    if (sess.role !== "manager" && sess.role !== "admin") return bad("権限がありません", 403);
+    targetUserId = qUserId;
+  }
+  return ok(await getRepos().monthlyReports.listByUser(targetUserId));
 }
 
 type SubmitBody = { userId?: string; ym: string; markdown: string; plan?: string };

--- a/src/app/manager/_app.tsx
+++ b/src/app/manager/_app.tsx
@@ -85,8 +85,12 @@ type ConsultDetail = {
 type ReportDetail = {
   kind: "月次報告";
   ym: string; // YYYY-MM
-  summary: string;
-  sections: { title: string; body: string }[];
+  // 旧/シード形式(summary + sections)
+  summary?: string;
+  sections?: { title: string; body: string }[];
+  // 隊員提出フロー(api/monthly-reports POST)の形式
+  body?: string;
+  plan?: string;
 };
 type ExpenseDetail = {
   kind: "経費";
@@ -1205,15 +1209,33 @@ function ReportDetailView({ d }: { d: ReportDetail }) {
         月次報告({d.ym} 分)
       </div>
 
-      <Label>サマリ</Label>
-      <Body>{d.summary}</Body>
+      {d.summary && (
+        <>
+          <Label>サマリ</Label>
+          <Body>{d.summary}</Body>
+        </>
+      )}
 
-      {d.sections.map((s) => (
+      {(d.sections ?? []).map((s) => (
         <React.Fragment key={s.title}>
           <Label>{s.title}</Label>
           <Body multiline>{s.body}</Body>
         </React.Fragment>
       ))}
+
+      {d.body && (
+        <>
+          <Label>本文</Label>
+          <Body multiline>{d.body}</Body>
+        </>
+      )}
+
+      {d.plan && (
+        <>
+          <Label>来月の計画</Label>
+          <Body multiline>{d.plan}</Body>
+        </>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## 概要
役場側の月報表示が実データ接続時に壊れる2件（H1・H2）を修正。

## 背景（不具合）
- **H1**: 月報グリッドの状態が**全員「未着手」**。GET `/api/monthly-reports` が `?userId` を無視し `requireAppUser` の本人分だけ返すため、manager が隊員ごとに叩いても状態が取れない。
- **H2**: 実際に隊員が提出した月報の**承認詳細を開くとクラッシュ**（`d.sections.map` の TypeError）。隊員提出フロー（`api/monthly-reports` POST）が保存する detail は `{ym, body, plan}` 形式だが、`ReportDetailView` は `{summary, sections[]}` を前提にしていた。

## 変更（許可域＝monthly-reports route / manager UI のみ）
- **monthly-reports GET**: `?userId` 指定時、要求者が manager/admin なら担当隊員の月報を返す（member は本人のみ、他人指定は403）。→ グリッド状態が実データで埋まる。
- **ReportDetailView / ReportDetail 型**: `summary`/`sections`/`body`/`plan` を任意化し、存在するものだけ防御的に描画。旧/シード形式（summary+sections）と隊員提出形式（body+plan）の両対応でクラッシュ解消。

## 制約遵守
- 編集は許可域のみ。**共有ファイルは無改修**。月報POSTの認可（別件 #77）は本PRでは触れていない。
- 1トピック1コミット（`7391dcc`）。

## 検証
- `tsc --noEmit` ✅ / `next build` ✅（develop ベース・worktree）。

## 別トピック（残）
- H3 担当隊員 roster（managed の名前join・members の muni スコープ）/ H5 MUNI二重定義・既読率（共有域・事前報告要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)