### PR TITLE
fix(manager): 担当隊員ロスターを実データ化(グリッド/配信先が空になる問題)

### DIFF
--- a/src/app/api/announcements/__tests__/post-authz.test.ts
+++ b/src/app/api/announcements/__tests__/post-authz.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// お知らせ配信(POST /api/announcements)の認可・なりすまし回帰テスト(PR #77)。
+// 配信は役場職員のみ。senderId/senderName は body を信用せずセッションから確定する。
+
+function reqPost(body: unknown) {
+  return new Request("http://test/api/announcements", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function post(role: string, devUserId: string, body: unknown) {
+  vi.resetModules();
+  vi.stubEnv("AUTH_PROVIDER", "none");
+  vi.stubEnv("DEV_USER_ROLE", role);
+  vi.stubEnv("DEV_USER_ID", devUserId);
+  const mod = await import("../route");
+  const res = await mod.POST(reqPost(body));
+  return { status: res.status, json: await res.json() };
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("POST /api/announcements 配信認可(#77 回帰)", () => {
+  it("member は役場名義で配信できない(403)", async () => {
+    const r = await post("member", "m1", { body: "勝手なお知らせ" });
+    expect(r.status).toBe(403);
+  });
+
+  it("manager でも本文が空なら 400", async () => {
+    const r = await post("manager", "s1", { body: "   " });
+    expect(r.status).toBe(400);
+  });
+
+  it("manager の配信は senderId/senderName を body ではなくセッションから確定する", async () => {
+    const r = await post("manager", "s1", {
+      body: "6 月例会の議題について",
+      senderId: "HACKER",
+      senderName: "なりすまし",
+    });
+    expect(r.status).toBe(201);
+    // body で渡した偽の senderName は無視され、セッションの s1(谷本 拓海)が記録される。
+    expect(r.json.sender).toBe("谷本 拓海");
+  });
+});

--- a/src/app/api/approvals/[id]/decide/__tests__/decide-authz.test.ts
+++ b/src/app/api/approvals/[id]/decide/__tests__/decide-authz.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// 承認/差戻し(decide)の認可ガード回帰テスト(PR #77)。
+// 役場職員(manager/admin)以外の自己承認・無権限承認を遮断していることを保証する。
+// AUTH_PROVIDER=none + DEV_USER_ROLE 切替で各ロールになりすます(vitest.config 参照)。
+
+function reqPost(body: unknown) {
+  return new Request("http://test/api/approvals/x/decide", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ロールを切り替えて route を再評価する(auth.ts は import 時に DEV_USER_ROLE を捕捉するため)。
+async function decide(role: string, id: string, body: unknown) {
+  vi.resetModules();
+  vi.stubEnv("AUTH_PROVIDER", "none");
+  vi.stubEnv("DEV_USER_ROLE", role);
+  vi.stubEnv("DEV_USER_ID", role === "member" ? "m1" : "s1");
+  const mod = await import("../route");
+  const res = await mod.POST(reqPost(body), { params: Promise.resolve({ id }) });
+  return { status: res.status, json: await res.json() };
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("POST /api/approvals/[id]/decide 認可ガード(#77 回帰)", () => {
+  it("member は承認できない(自己承認・無権限承認を 403 で遮断)", async () => {
+    const r = await decide("member", "a1", { action: "approve" });
+    expect(r.status).toBe(403);
+    expect(r.json.error).toContain("承認権限");
+  });
+
+  it("member はロールゲートで弾かれ、存在しない id でも DB 参照前に 403", async () => {
+    const r = await decide("member", "no-such-id", { action: "approve" });
+    expect(r.status).toBe(403);
+  });
+
+  it("manager は承認できる(多段ルートは次ステップへ前進し pending 継続)", async () => {
+    // a4: 担当課 → 受入団体 → 企画課 の 3 段、current_step=0。
+    const r = await decide("manager", "a4", { action: "approve" });
+    expect(r.status).toBe(200);
+    expect(r.json.result).toBe("pending");
+  });
+
+  it("manager の最終承認で approved になり、再処理は 409", async () => {
+    // a2: 最終ステップが pending(current_step=1)。1 回承認で確定。
+    const first = await decide("manager", "a2", { action: "approve" });
+    expect(first.status).toBe(200);
+    expect(first.json.result).toBe("approved");
+
+    const again = await decide("manager", "a2", { action: "approve" });
+    expect(again.status).toBe(409);
+  });
+
+  it("manager の差戻しは理由 5 文字未満で 400、妥当な理由で rejected", async () => {
+    const tooShort = await decide("manager", "a3", { action: "reject", comment: "x" });
+    expect(tooShort.status).toBe(400);
+
+    const ok = await decide("manager", "a3", { action: "reject", comment: "添付不足のため差戻します" });
+    expect(ok.status).toBe(200);
+    expect(ok.json.result).toBe("rejected");
+  });
+});

--- a/src/app/api/monthly-reports/__tests__/list-authz.test.ts
+++ b/src/app/api/monthly-reports/__tests__/list-authz.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// 月報一覧(GET /api/monthly-reports)の閲覧スコープ回帰テスト(PR #79)。
+// 既定は本人の月報。?userId で他人の月報を引けるのは役場職員(manager/admin)のみ。
+
+async function getList(role: string, devUserId: string, qUserId?: string) {
+  vi.resetModules();
+  vi.stubEnv("AUTH_PROVIDER", "none");
+  vi.stubEnv("DEV_USER_ROLE", role);
+  vi.stubEnv("DEV_USER_ID", devUserId);
+  const mod = await import("../route");
+  const url = qUserId
+    ? `http://test/api/monthly-reports?userId=${qUserId}`
+    : "http://test/api/monthly-reports";
+  const res = await mod.GET(new Request(url));
+  return { status: res.status, json: await res.json() };
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("GET /api/monthly-reports 閲覧スコープ(#79 回帰)", () => {
+  it("member は他人の userId を指定すると 403", async () => {
+    const r = await getList("member", "m2", "m1");
+    expect(r.status).toBe(403);
+  });
+
+  it("manager は担当隊員(m1)の月報を ?userId で閲覧できる", async () => {
+    // m1(田中 あかり)はシードに月報あり。s1 は manager。
+    const r = await getList("manager", "s1", "m1");
+    expect(r.status).toBe(200);
+    expect(Array.isArray(r.json)).toBe(true);
+    expect(r.json.length).toBeGreaterThan(0);
+  });
+
+  it("member は userId 未指定なら自分(m1)の月報を取得できる", async () => {
+    const r = await getList("member", "m1");
+    expect(r.status).toBe(200);
+    expect(Array.isArray(r.json)).toBe(true);
+    expect(r.json.length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/manager/_app.tsx
+++ b/src/app/manager/_app.tsx
@@ -416,6 +416,13 @@ export function ManagerApp() {
         const ms = await apiGet<MemberDTO[]>("/api/members");
         const mapped: Member[] = ms.map((m) => ({ id: m.id, name: m.name, role: m.role, initials: initialsOf(m.name) }));
         setMembers(mapped);
+        // 実データの隊員を既定の担当・配信先に反映(モック名のままだとロスター/配信先が空になる)。
+        // PoC では自治体の全隊員を担当として表示し、設定で絞り込み可能にする。
+        const memberNames = mapped.map((m) => m.name);
+        if (memberNames.length) {
+          setManaged(memberNames);
+          setNoticeTargets(memberNames);
+        }
         const entries = await Promise.all(
           mapped.map(async (m) => {
             try {
@@ -1655,7 +1662,7 @@ function NoticeDetailSheet({ notice, onClose }: { notice: NoticeItem; onClose: (
 }
 
 function SettingsSheet({ onClose }: { onClose: () => void }) {
-  const { managed, setManaged } = useApp();
+  const { managed, setManaged, members } = useApp();
   const [local, setLocal] = React.useState<string[]>(managed);
 
   function toggle(name: string) {
@@ -1686,10 +1693,10 @@ function SettingsSheet({ onClose }: { onClose: () => void }) {
         </p>
 
         <ul className="mt-3 space-y-px">
-          {ALL_MEMBERS.map((m) => {
+          {members.map((m) => {
             const on = local.includes(m.name);
             return (
-              <li key={m.name}>
+              <li key={m.id}>
                 <button
                   onClick={() => toggle(m.name)}
                   className="flex w-full items-center gap-3 border-b border-slate-100 py-2.5 text-left hover:bg-slate-50"


### PR DESCRIPTION
## 概要
担当隊員ロスターを実データ化し、あわせて役場API認可の回帰テスト(#77/#79)を追加。
develop(#77 認可厳格化 / #79 月報表示 / #91 vitest基盤)をマージ取り込み済み。

## 変更
### fix(manager): 担当隊員ロスター実データ化
- `managed`/`noticeTargets` がモック `ALL_MEMBERS` 名で固定され、`roster` が実隊員名と交差せず空集合だった問題を修正。
- `/api/members` 取得成功時に実隊員名で初期化。設定シートも実 `members` 列挙に。
- → 月報グリッド・お知らせ配信先に担当隊員が出るようになる(#79 と相補)。
- `src/app/manager/_app.tsx` のみ・共有ファイル無改修。

### test(manager): 役場API認可の回帰テスト(vitest)
`AUTH_PROVIDER=none` + `DEV_USER_ROLE` 切替で各ロールになりすまし、route ハンドラを直接検証(許可域に新規追加のみ)。
- `approvals/[id]/decide`: member の自己承認/無権限承認 → 403、manager の多段前進・最終承認(approved)・再処理 409・差戻し検証。
- `monthly-reports` GET: 他人 `userId` 閲覧は manager/admin のみ(member は 403)。
- `announcements` POST: member の役場名義配信 → 403、`sender` は body ではなくセッションから確定(なりすまし防止)。

## 検証
- `npm test` → 13 passed (4 files) ✅
- `tsc --noEmit` 通過 ✅

## 補足: E2E(Playwright)は別途要相談
Playwright は未導入で、`AUTH_PROVIDER=none` では特定メール(e2e-manager@example.com)でのログイン動線が無い(固定 DEV ユーザーになる)。
導入には共有ファイル(package.json/lockfile)・ルート設定・ブラウザDL・実認証(Supabase テストアカウント)が必要なため、ルール3に従い事前相談とする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)