### PR TITLE
feat(super): ユーザー削除機能(DELETE /api/super/users/[id])

### DIFF
--- a/src/app/api/super/users/[id]/route.ts
+++ b/src/app/api/super/users/[id]/route.ts
@@ -31,3 +31,18 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
   if (!updated) return bad("ユーザーが見つかりません", 404);
   return ok(updated);
 }
+
+/** DELETE /api/super/users/[id] — ユーザーを削除(super 専用) */
+export async function DELETE(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const sess = await requireSuper();
+  if (sess instanceof Response) return sess;
+  const { id } = await params;
+
+  // 事故防止: super 自身の削除をブロック
+  if (sess.userId && sess.userId === id) {
+    return bad("自分自身は削除できません", 400);
+  }
+
+  await getRepos().super.deleteUser(id);
+  return ok(null, 204);
+}

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -272,6 +272,10 @@ export const sqliteRepos: Repos = {
       return (await sqliteRepos.super.listUsers()).find((u) => u.id === id);
     },
 
+    async deleteUser(id): Promise<void> {
+      run("DELETE FROM users WHERE id=?", [id]);
+    },
+
     async getContract(municipalityId): Promise<ContractDTO | null> {
       const m = get<{
         id: string; name: string; annual_budget: number;

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -370,6 +370,10 @@ export const supabaseRepos: Repos = {
       return (await supabaseRepos.super.listUsers()).find((u) => u.id === id);
     },
 
+    async deleteUser(id): Promise<void> {
+      await supabase().from("users").delete().eq("id", id);
+    },
+
     async getContract(municipalityId): Promise<ContractDTO | null> {
       const { data } = await supabase()
         .from("municipalities")

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -166,6 +166,8 @@ export interface Repos {
     listUsers(opts?: { municipalityId?: string; role?: string; status?: string }): Promise<SuperUserRow[]>;
     /** #66: ユーザーの role/status/所属自治体を更新 */
     updateUser(id: string, patch: { role?: string; status?: string; municipalityId?: string }): Promise<SuperUserRow | undefined>;
+    /** ユーザーを削除 */
+    deleteUser(id: string): Promise<void>;
     /** #66: 契約情報の取得 */
     getContract(municipalityId: string): Promise<ContractDTO | null>;
     /** #66: 契約情報の部分更新 */


### PR DESCRIPTION
## 概要
super がユーザーを削除できる機能。共有developツリーに浮いていた未コミット変更を退避し、欠けていた sqlite 実装を補完して完成させた。

## 変更
- `DELETE /api/super/users/[id]`：super専用(`requireSuper`)・**自分自身の削除はブロック**
- `Repos.super.deleteUser` を types に追加、supabase.ts / sqlite.ts に実装（3層整合）

## 備考
- sqlite 版は単純 DELETE（supabase 版と同等）。FK 制約のある関連データ削除のカスケードは未対応 → 必要なら別途。
- CI(Vercel) でビルド検証。Workers Builds の fail は既存の無関係エラー。

🤖 Generated with [Claude Code](https://claude.com/claude-code)