### PR TITLE
release: super削除/admin修正3件/manager修正2件 を本番へ

### DIFF
--- a/src/app/admin/_app.tsx
+++ b/src/app/admin/_app.tsx
@@ -822,7 +822,12 @@ function RouteEditSheet({ route, onClose }: { route: ApprovalRoute | null; onClo
     setSteps((ss) => ss.filter((_, idx) => idx !== i));
   }
 
-  const canSave = !!name.trim() && steps.length > 0 && steps.every((s) => s.approverLabel.trim());
+  // host_org ステップは受入団体の選択(hostOrganizationId)を必須にする。
+  // 未選択のまま保存すると、承認フローに実体のない受入団体ステップが残ってしまうため。
+  const canSave =
+    !!name.trim() &&
+    steps.length > 0 &&
+    steps.every((s) => (s.approverType === "host_org" ? !!s.hostOrganizationId : !!s.approverLabel.trim()));
 
   async function save() {
     const normalized = steps.map((s, i) => ({

--- a/src/app/admin/_app.tsx
+++ b/src/app/admin/_app.tsx
@@ -17,7 +17,7 @@ import {
   ChevronUp,
   ChevronDown,
 } from "lucide-react";
-import { BUDGET_CATEGORIES, ANNUAL_BUDGET_TOTAL } from "@/lib/budget";
+import { BUDGET_CATEGORIES, ANNUAL_BUDGET_TOTAL, defaultAllocationList } from "@/lib/budget";
 
 type BudgetLine = { category: string; amountLimit: number; used: number; remaining: number };
 
@@ -98,7 +98,7 @@ type Ctx = {
   assignments: Record<string, string[]>;
   hosts: HostOrg[];
   routes: ApprovalRoute[];
-  upsertMember: (m: Member) => void | Promise<void>;
+  upsertMember: (m: Member) => Promise<Member>;
   removeMember: (id: string) => void | Promise<void>;
   upsertStaff: (s: Staff) => void | Promise<void>;
   removeStaff: (id: string) => void | Promise<void>;
@@ -164,6 +164,7 @@ export function AdminApp() {
         copy[idx] = saved;
         return copy;
       });
+      return saved;
     },
     removeMember: async (id) => {
       await apiDelete(`/api/members/${id}`);
@@ -1002,8 +1003,10 @@ function MemberEditSheet({
   const [approvalRouteId, setApprovalRouteId] = React.useState(member?.approvalRouteId ?? "");
   const expenseRoutes = routes.filter((r) => r.kind === "経費");
 
-  // 費目別予算枠(既存隊員のみ編集可。新規は作成時に既定配分が自動生成される)
-  const [budget, setBudget] = React.useState<BudgetLine[] | null>(null);
+  // 費目別予算枠。既存隊員は現状を取得し、新規隊員は既定配分を初期表示して作成と同時に保存する。
+  const [budget, setBudget] = React.useState<BudgetLine[] | null>(
+    member ? null : defaultAllocationList().map((a) => ({ ...a, used: 0, remaining: a.amountLimit }))
+  );
   React.useEffect(() => {
     if (!member) return;
     apiGet<BudgetLine[]>(`/api/budgets?userId=${member.id}`)
@@ -1018,7 +1021,7 @@ function MemberEditSheet({
   const canSave = !!(name.trim() && role.trim());
 
   async function save() {
-    await upsertMember({
+    const saved = await upsertMember({
       id: member?.id ?? `m${Date.now()}`,
       name: name.trim(),
       role: role.trim(),
@@ -1027,9 +1030,11 @@ function MemberEditSheet({
       hostOrganizationId: hostOrganizationId || undefined,
       approvalRouteId: approvalRouteId || undefined,
     });
-    if (member && budget) {
+    // 新規・既存いずれも、編集した費目別予算枠を保存する(新規は作成後の id に対して反映)。
+    const targetId = member?.id ?? saved?.id;
+    if (targetId && budget) {
       await apiPut("/api/budgets", {
-        userId: member.id,
+        userId: targetId,
         allocations: budget.map((b) => ({ category: b.category, amountLimit: b.amountLimit })),
       });
     }
@@ -1106,7 +1111,7 @@ function MemberEditSheet({
           ))}
         </select>
 
-        {!isNew && budget && (
+        {budget && (
           <>
             <Label>費目別予算枠(年額 / 合計 ¥{budgetTotal.toLocaleString()})</Label>
             <p className="mt-1 text-[11px] text-slate-500">

--- a/src/app/api/admin/invites/[token]/route.ts
+++ b/src/app/api/admin/invites/[token]/route.ts
@@ -1,41 +1,28 @@
 import { ok, bad } from "@/lib/api/http";
-import { getDb } from "@/lib/db";
+import { getRepos } from "@/lib/db/repositories";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-type TokenRow = {
-  token: string;
-  email: string | null;
-  role: string;
-  municipality_name: string;
-  expires_at: string;
-  used_at: string | null;
-};
-
 /** GET /api/admin/invites/[token] — トークン検証(signup ページが呼ぶ) */
 export async function GET(_req: Request, { params }: { params: Promise<{ token: string }> }) {
   const { token } = await params;
-  const row = getDb()
-    .prepare("SELECT * FROM invite_tokens WHERE token=?")
-    .get(token) as TokenRow | undefined;
+  const row = await getRepos().invites.findByToken(token);
 
   if (!row) return bad("招待リンクが無効です", 404);
-  if (row.used_at) return bad("この招待リンクはすでに使用されています", 410);
-  if (new Date(row.expires_at) < new Date()) return bad("招待リンクの有効期限が切れています", 410);
+  if (row.usedAt) return bad("この招待リンクはすでに使用されています", 410);
+  if (new Date(row.expiresAt) < new Date()) return bad("招待リンクの有効期限が切れています", 410);
 
   return ok({
     email: row.email,
     role: row.role,
-    municipalityName: row.municipality_name,
+    municipalityName: row.municipalityName,
   });
 }
 
 /** PATCH /api/admin/invites/[token] — 使用済みマーク(signup 完了時に呼ぶ) */
 export async function PATCH(_req: Request, { params }: { params: Promise<{ token: string }> }) {
   const { token } = await params;
-  getDb()
-    .prepare("UPDATE invite_tokens SET used_at=datetime('now') WHERE token=? AND used_at IS NULL")
-    .run(token);
+  await getRepos().invites.markUsed(token);
   return ok({ ok: true });
 }

--- a/src/app/api/admin/invites/route.ts
+++ b/src/app/api/admin/invites/route.ts
@@ -1,6 +1,6 @@
 import { ok, bad, readJson } from "@/lib/api/http";
 import { requireAdmin } from "@/lib/api/auth";
-import { getDb } from "@/lib/db";
+import { getRepos } from "@/lib/db/repositories";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -18,19 +18,15 @@ export async function POST(req: Request) {
 
   const { email, role = "member", municipalityName = "" } = await readJson<CreateBody>(req);
 
-  // ランダムトークン生成
-  const token = Array.from(crypto.getRandomValues(new Uint8Array(24)))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-
-  // 7日間有効
-  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
-
+  let token: string;
+  let expiresAt: string;
   try {
-    getDb().prepare(
-      `INSERT INTO invite_tokens (token, email, role, municipality_name, expires_at)
-       VALUES (?, ?, ?, ?, ?)`
-    ).run(token, email ?? null, role, municipalityName, expiresAt);
+    ({ token, expiresAt } = await getRepos().invites.create({
+      email: email?.trim() || null,
+      role,
+      municipalityName,
+      createdBy: sess.userId,
+    }));
   } catch {
     return bad("DB error", 500);
   }

--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -1,22 +1,24 @@
-import { ok, readJson } from "@/lib/api/http";
+import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
-import { requireSession } from "@/lib/api/auth";
+import { requireAppUser } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
 
+// お知らせ閲覧はログイン必須(隊員も自町のお知らせを読む)。未認証アクセスを遮断。
 export async function GET(req: Request) {
+  const sess = await requireAppUser();
+  if (sess instanceof Response) return sess;
   const sp = new URL(req.url).searchParams;
   const muni = sp.get("muni") ?? MUNI;
   const kinds = sp.get("kinds")?.split(",").map((k) => k.trim()).filter(Boolean);
   return ok(await getRepos().announcements.list(muni, kinds));
 }
 
+// senderId/senderName は受け付けない(なりすまし防止・サーバ側でセッションから確定)
 type CreateBody = {
-  senderId?: string;
-  senderName?: string;
   kind?: "info" | "rule" | "qa";
   isPinned?: boolean;
   title?: string;
@@ -25,8 +27,24 @@ type CreateBody = {
 };
 
 export async function POST(req: Request) {
-  const sess = await requireSession();
+  const sess = await requireAppUser();
   if (sess instanceof Response) return sess;
+  // 一斉配信は役場職員(manager/admin)のみ。隊員が役場名義で送るのを遮断。
+  if (sess.role !== "manager" && sess.role !== "admin") return bad("お知らせの配信権限がありません", 403);
   const b = await readJson<CreateBody>(req);
-  return ok(await getRepos().announcements.create(b), 201);
+  if (!b.body?.trim()) return bad("本文が必要です");
+  const repos = getRepos();
+  const senderName = (await repos.users.nameOf(sess.userId)) ?? "役場";
+  return ok(
+    await repos.announcements.create({
+      senderId: sess.userId,
+      senderName,
+      kind: b.kind,
+      isPinned: b.isPinned,
+      title: b.title,
+      body: b.body,
+      targets: b.targets,
+    }),
+    201
+  );
 }

--- a/src/app/api/approval-routes/route.ts
+++ b/src/app/api/approval-routes/route.ts
@@ -1,12 +1,16 @@
-import { ok, readJson } from "@/lib/api/http";
+import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
 import type { RouteStepDTO } from "@/lib/db/repositories/types";
-import { requireAdmin } from "@/lib/api/auth";
+import { requireAdmin, requireAppUser } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+// 承認ルート構成は役場職員(manager/admin)のみ閲覧可。未認証アクセスを遮断。
 export async function GET() {
+  const sess = await requireAppUser();
+  if (sess instanceof Response) return sess;
+  if (sess.role !== "manager" && sess.role !== "admin") return bad("権限がありません", 403);
   return ok(await getRepos().routes.list());
 }
 

--- a/src/app/api/approvals/[id]/decide/route.ts
+++ b/src/app/api/approvals/[id]/decide/route.ts
@@ -1,7 +1,7 @@
 import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
 import { applyApprove, applyReject, type ApprovalStep } from "@/lib/workflow";
-import { requireSession } from "@/lib/api/auth";
+import { requireAppUser } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -9,8 +9,10 @@ export const dynamic = "force-dynamic";
 type Body = { action: "approve" | "reject"; comment?: string };
 
 export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const sess = await requireSession();
+  const sess = await requireAppUser();
   if (sess instanceof Response) return sess;
+  // 承認/差戻しは役場職員(manager/admin)のみ。隊員の自己承認・無権限承認を遮断。
+  if (sess.role !== "manager" && sess.role !== "admin") return bad("承認権限がありません", 403);
   const { id } = await params;
   const b = await readJson<Body>(req);
   const repos = getRepos();

--- a/src/app/api/approvals/route.ts
+++ b/src/app/api/approvals/route.ts
@@ -1,5 +1,6 @@
-import { ok } from "@/lib/api/http";
+import { ok, bad } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
+import { requireAppUser } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -7,7 +8,11 @@ export const dynamic = "force-dynamic";
 const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
 
 // 進行中(pending)の承認のみ返す。完了/差戻しはキューから外れる。
+// 承認キューは役場職員(manager/admin)のみ閲覧可。未認証アクセスを遮断。
 export async function GET(req: Request) {
+  const sess = await requireAppUser();
+  if (sess instanceof Response) return sess;
+  if (sess.role !== "manager" && sess.role !== "admin") return bad("権限がありません", 403);
   const muni = new URL(req.url).searchParams.get("muni") ?? MUNI;
   return ok(await getRepos().approvals.listPending(muni));
 }

--- a/src/app/api/monthly-reports/route.ts
+++ b/src/app/api/monthly-reports/route.ts
@@ -1,13 +1,12 @@
 import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
 import { expandRoute } from "@/lib/workflow";
-import { requireAppUser, requireSession } from "@/lib/api/auth";
+import { requireAppUser } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
-const DEFAULT_USER = process.env.NEXT_PUBLIC_DEMO_MEMBER_ID ?? "a1000000-0000-4000-8000-000000000001";
 
 export async function GET() {
   const sess = await requireAppUser();
@@ -15,18 +14,19 @@ export async function GET() {
   return ok(await getRepos().monthlyReports.listByUser(sess.userId));
 }
 
-type SubmitBody = { userId?: string; ym: string; markdown: string; plan?: string };
+type SubmitBody = { ym: string; markdown: string; plan?: string };
 
 /** POST /api/monthly-reports — 月報を役場に提出(永続化 + 承認キュー投入) */
 export async function POST(req: Request) {
-  const sess = await requireSession();
+  const sess = await requireAppUser();
   if (sess instanceof Response) return sess;
   const b = await readJson<SubmitBody>(req);
   if (!b.ym || !/^\d{4}-\d{2}$/.test(b.ym)) return bad("ym(YYYY-MM)が必要です");
   if (!b.markdown?.trim()) return bad("月報本文が空です");
 
   const repos = getRepos();
-  const userId = b.userId ?? DEFAULT_USER;
+  // なりすまし防止: 提出者はセッション本人に固定(body の userId は受け付けない)
+  const userId = sess.userId;
   const report = await repos.monthlyReports.submit({ userId, ym: b.ym, markdown: b.markdown.trim(), plan: b.plan?.trim() });
 
   // 役場側の承認キューに投入(月次報告 ルート)

--- a/src/app/api/monthly-reports/route.ts
+++ b/src/app/api/monthly-reports/route.ts
@@ -9,10 +9,17 @@ export const dynamic = "force-dynamic";
 const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
 const DEFAULT_USER = process.env.NEXT_PUBLIC_DEMO_MEMBER_ID ?? "a1000000-0000-4000-8000-000000000001";
 
-export async function GET() {
+export async function GET(req: Request) {
   const sess = await requireAppUser();
   if (sess instanceof Response) return sess;
-  return ok(await getRepos().monthlyReports.listByUser(sess.userId));
+  // 既定は本人。役場職員(manager/admin)は ?userId で担当隊員の月報を閲覧可。
+  let targetUserId = sess.userId;
+  const qUserId = new URL(req.url).searchParams.get("userId");
+  if (qUserId && qUserId !== sess.userId) {
+    if (sess.role !== "manager" && sess.role !== "admin") return bad("権限がありません", 403);
+    targetUserId = qUserId;
+  }
+  return ok(await getRepos().monthlyReports.listByUser(targetUserId));
 }
 
 type SubmitBody = { userId?: string; ym: string; markdown: string; plan?: string };

--- a/src/app/api/super/users/[id]/route.ts
+++ b/src/app/api/super/users/[id]/route.ts
@@ -31,3 +31,18 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
   if (!updated) return bad("ユーザーが見つかりません", 404);
   return ok(updated);
 }
+
+/** DELETE /api/super/users/[id] — ユーザーを削除(super 専用) */
+export async function DELETE(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const sess = await requireSuper();
+  if (sess instanceof Response) return sess;
+  const { id } = await params;
+
+  // 事故防止: super 自身の削除をブロック
+  if (sess.userId && sess.userId === id) {
+    return bad("自分自身は削除できません", 400);
+  }
+
+  await getRepos().super.deleteUser(id);
+  return ok(null, 204);
+}

--- a/src/app/manager/_app.tsx
+++ b/src/app/manager/_app.tsx
@@ -85,8 +85,12 @@ type ConsultDetail = {
 type ReportDetail = {
   kind: "月次報告";
   ym: string; // YYYY-MM
-  summary: string;
-  sections: { title: string; body: string }[];
+  // 旧/シード形式(summary + sections)
+  summary?: string;
+  sections?: { title: string; body: string }[];
+  // 隊員提出フロー(api/monthly-reports POST)の形式
+  body?: string;
+  plan?: string;
 };
 type ExpenseDetail = {
   kind: "経費";
@@ -1205,15 +1209,33 @@ function ReportDetailView({ d }: { d: ReportDetail }) {
         月次報告({d.ym} 分)
       </div>
 
-      <Label>サマリ</Label>
-      <Body>{d.summary}</Body>
+      {d.summary && (
+        <>
+          <Label>サマリ</Label>
+          <Body>{d.summary}</Body>
+        </>
+      )}
 
-      {d.sections.map((s) => (
+      {(d.sections ?? []).map((s) => (
         <React.Fragment key={s.title}>
           <Label>{s.title}</Label>
           <Body multiline>{s.body}</Body>
         </React.Fragment>
       ))}
+
+      {d.body && (
+        <>
+          <Label>本文</Label>
+          <Body multiline>{d.body}</Body>
+        </>
+      )}
+
+      {d.plan && (
+        <>
+          <Label>来月の計画</Label>
+          <Body multiline>{d.plan}</Body>
+        </>
+      )}
     </>
   );
 }

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -272,6 +272,10 @@ export const sqliteRepos: Repos = {
       return (await sqliteRepos.super.listUsers()).find((u) => u.id === id);
     },
 
+    async deleteUser(id): Promise<void> {
+      run("DELETE FROM users WHERE id=?", [id]);
+    },
+
     async getContract(municipalityId): Promise<ContractDTO | null> {
       const m = get<{
         id: string; name: string; annual_budget: number;

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -558,6 +558,42 @@ export const sqliteRepos: Repos = {
     },
   },
 
+  invites: {
+    async create({ email, role, municipalityName, createdBy }) {
+      const token = Array.from(crypto.getRandomValues(new Uint8Array(24)))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+      run(
+        "INSERT INTO invite_tokens (token,email,role,municipality_name,created_by,expires_at) VALUES (?,?,?,?,?,?)",
+        [token, email, role, municipalityName, createdBy, expiresAt]
+      );
+      return { token, expiresAt };
+    },
+    async findByToken(token) {
+      const r = get<{
+        token: string;
+        email: string | null;
+        role: string;
+        municipality_name: string;
+        expires_at: string;
+        used_at: string | null;
+      }>("SELECT * FROM invite_tokens WHERE token=?", [token]);
+      if (!r) return null;
+      return {
+        token: r.token,
+        email: r.email,
+        role: r.role,
+        municipalityName: r.municipality_name,
+        expiresAt: r.expires_at,
+        usedAt: r.used_at,
+      };
+    },
+    async markUsed(token) {
+      run("UPDATE invite_tokens SET used_at=datetime('now') WHERE token=? AND used_at IS NULL", [token]);
+    },
+  },
+
   topics: {
     async list(userId, kind = "topic") {
       const col = kind === "type" ? "activity_type" : "topic";

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -749,6 +749,47 @@ export const supabaseRepos: Repos = {
     },
   },
 
+  invites: {
+    async create({ email, role, municipalityName, createdBy }) {
+      const token = Array.from(crypto.getRandomValues(new Uint8Array(24)))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+      await supabase().from("invite_tokens").insert({
+        token,
+        email,
+        role,
+        municipality_name: municipalityName,
+        created_by: createdBy,
+        expires_at: expiresAt,
+      });
+      return { token, expiresAt };
+    },
+    async findByToken(token) {
+      const { data } = await supabase()
+        .from("invite_tokens")
+        .select("token, email, role, municipality_name, expires_at, used_at")
+        .eq("token", token)
+        .maybeSingle();
+      if (!data) return null;
+      return {
+        token: data.token as string,
+        email: (data.email as string | null) ?? null,
+        role: data.role as string,
+        municipalityName: data.municipality_name as string,
+        expiresAt: data.expires_at as string,
+        usedAt: (data.used_at as string | null) ?? null,
+      };
+    },
+    async markUsed(token) {
+      await supabase()
+        .from("invite_tokens")
+        .update({ used_at: new Date().toISOString() })
+        .eq("token", token)
+        .is("used_at", null);
+    },
+  },
+
   topics: {
     async list(userId, kind = "topic") {
       const col = kind === "type" ? "activity_type" : "topic";

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -370,6 +370,10 @@ export const supabaseRepos: Repos = {
       return (await supabaseRepos.super.listUsers()).find((u) => u.id === id);
     },
 
+    async deleteUser(id): Promise<void> {
+      await supabase().from("users").delete().eq("id", id);
+    },
+
     async getContract(municipalityId): Promise<ContractDTO | null> {
       const { data } = await supabase()
         .from("municipalities")

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -166,6 +166,8 @@ export interface Repos {
     listUsers(opts?: { municipalityId?: string; role?: string; status?: string }): Promise<SuperUserRow[]>;
     /** #66: ユーザーの role/status/所属自治体を更新 */
     updateUser(id: string, patch: { role?: string; status?: string; municipalityId?: string }): Promise<SuperUserRow | undefined>;
+    /** ユーザーを削除 */
+    deleteUser(id: string): Promise<void>;
     /** #66: 契約情報の取得 */
     getContract(municipalityId: string): Promise<ContractDTO | null>;
     /** #66: 契約情報の部分更新 */

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -47,6 +47,16 @@ export type RouteDTO = { id: string; name: string; kind: string; isDefault: bool
 // 費目別予算枠(1隊員 × 年度 × 費目):枠 / 使用(committed) / 残額
 export type BudgetLineDTO = { category: string; amountLimit: number; used: number; remaining: number };
 
+// 招待トークン(#63)。used/expired の HTTP 判定は route 側で行うため生に近い形で返す。
+export type InviteRow = {
+  token: string;
+  email: string | null;
+  role: string;
+  municipalityName: string;
+  expiresAt: string;
+  usedAt: string | null;
+};
+
 // AI 月報生成プロンプト用の生ログ
 export type LogForAI = {
   activity_type: string;
@@ -202,6 +212,13 @@ export interface Repos {
   budgets: {
     summaryByUser(userId: string, fiscalYear: string): Promise<BudgetLineDTO[]>;
     upsert(userId: string, fiscalYear: string, allocations: { category: string; amountLimit: number }[]): Promise<BudgetLineDTO[]>;
+  };
+  invites: {
+    /** トークンと 7 日有効期限を採番して発行する */
+    create(i: { email: string | null; role: string; municipalityName: string; createdBy: string }): Promise<{ token: string; expiresAt: string }>;
+    findByToken(token: string): Promise<InviteRow | null>;
+    /** used_at が未設定のときだけ使用済みにする */
+    markUsed(token: string): Promise<void>;
   };
   topics: {
     list(userId: string, kind?: string): Promise<string[]>;


### PR DESCRIPTION
## 概要
develop に集約した6本を本番(main)へリリース。

## 含まれる変更
- **super**: ユーザー削除機能 DELETE /api/super/users/[id]（#89）
- **admin**: 招待トークンをRepos経由化・Supabase対応（#78）/ 承認ルートの受入団体ステップ必須化（#75）/ 新規隊員作成時に費目別予算枠を編集可（#76）
- **manager**: 役場側APIの認可厳格化（なりすまし/越境/自己承認遮断）（#77）/ 月報の実データ表示修正（#79）

## 検証
- 6本統合後の develop を Vercel ビルド success 済（fc9fd17）
- Workers Builds の fail は既存の無関係エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)