### PR TITLE
fix(super): 契約・課金管理UIをMVPから撤去しPhase2へ延期(#72/#73)+ superユニットテスト

### DIFF
--- a/docs/30_contract_mvp_phase2.md
+++ b/docs/30_contract_mvp_phase2.md
@@ -1,0 +1,63 @@
+# ADR-30: 契約・課金管理機能は Phase 2 に延期(UI 撤去)
+
+**Status**: Decided (2026-07-01)
+**Related Issues**: #72(契約取得エラー)/ #73(仕様見直し・MVP から除外)/ #68(4機能実装)
+
+## Context
+
+PR #68 で運営者(super)ダッシュボードに4機能を実装した:
+
+1. ✅ 自治体ドリルダウン詳細
+2. ✅ アカウント/ロール管理
+3. ⚠️ **契約・課金管理** ← 本 ADR の対象
+4. ✅ 横断 KPI/分析
+
+本番で「契約」ボタンを押すと **「契約情報の取得に失敗しました」**(#72)になる。
+原因は契約用 `contract_*` カラムの本番スキーマ未適用 + 課金フロー(請求書・決済)が
+そもそも未実装で、「記録だけの半完成機能」が露出している状態だった。
+
+## Decision
+
+**契約・課金管理 UI を MVP から撤去し、Phase 2(Year 2 以降)に延期する。**
+
+### 実装内容(UI 撤去)
+
+`src/app/super/_app.tsx` から以下を削除:
+
+- 自治体テーブル各行の「契約」ボタン
+- 契約モーダル(`ContractModal` コンポーネント)とその呼び出し・state
+- 契約専用の型/ラベル import(`ContractDTO` / `PLAN_LABEL` / `STATUS_LABEL` / `FileText`)
+- 見出し「契約自治体」→「自治体」、空表示文言も同様に変更
+
+### 温存するもの(Phase 2 で再利用)
+
+- API ルート `src/app/api/super/municipalities/[id]/contract/route.ts`(GET/PATCH)
+- Repository メソッド(`getContract` / `updateContract`)と `ContractDTO` 型
+- migration の `contract_*` カラム定義
+
+→ サーバ側は無害(誰も叩かない)なので残置。Phase 2 は UI を復活させるだけ。
+
+## Rationale
+
+1. **#72 の即時解消**: ボタンが無ければエラーも出ない。本番 UX を直ちに改善。
+2. **MVP スコープの明確化**: 契約・課金は「自社の台帳」であり、隊員・自治体ユーザー
+   への直接価値が薄い。課金体系は Year 2 の県共同調達確定後に最適化する(#73)。
+3. **複雑性の削減**: 残り3機能(ドリルダウン/アカウント/KPI)で運営側は十分機能する。
+
+## Alternatives Considered
+
+| 案 | 評価 |
+|---|---|
+| そのまま残す(ボタン+エラー表示) | ❌ UX 最悪、バグレポート増 |
+| コメントアウトで温存 | ⚠️ 未使用 import/コンポーネントが lint を汚す |
+| **UI 撤去 + API/Repos 温存(採用)** | ✅ build クリーン、Phase 2 は git 履歴から復活容易 |
+
+## Phase 2 復活手順
+
+1. 本 PR を `git revert` するか、`git show <this-commit>:src/app/super/_app.tsx` で
+   契約 UI 差分を参照して `_app.tsx` に再導入。
+2. 本番に `contract_*` カラムの migration を適用。
+3. 請求書発行・決済 API を新規実装(本 MVP では未着手)。
+4. テスト・デプロイ。
+
+API ルートと Repository は無変更で使い回せる。

--- a/src/app/super/_app.tsx
+++ b/src/app/super/_app.tsx
@@ -17,19 +17,18 @@ import {
   ClipboardCheck,
   TrendingUp,
   TrendingDown,
-  FileText,
 } from "lucide-react";
 import type {
   SuperMuniDetail,
   SuperUserRow,
-  ContractDTO,
   SuperAnalytics,
 } from "@/lib/db/repositories/types";
 
 /* ============================================================
    super 運営者ダッシュボード(#64 / #65 / #66)
    全自治体横断のサマリ + 自治体作成・admin 招待オンボーディング(#65)
-   + 自治体ドリルダウン・アカウント管理・契約管理・分析(#66)。
+   + 自治体ドリルダウン・アカウント管理・分析(#66)。
+   ※ 契約・課金管理 UI は Phase 2 へ延期(#72/#73, ADR-30)。API/Repos は温存。
    super ロールのみアクセス可。
    ============================================================ */
 
@@ -49,14 +48,6 @@ type Overview = {
 
 type Tab = "overview" | "accounts" | "analytics";
 
-const PLAN_LABEL: Record<ContractDTO["plan"], string> = { year1: "Year1", year2: "Year2", year3: "Year3" };
-const STATUS_LABEL: Record<ContractDTO["contractStatus"], string> = {
-  trial: "トライアル",
-  active: "契約中",
-  suspended: "停止",
-  ended: "終了",
-};
-
 export function SuperApp() {
   const [data, setData] = React.useState<Overview | null>(null);
   const [error, setError] = React.useState<string | null>(null);
@@ -70,9 +61,6 @@ export function SuperApp() {
   const [detailId, setDetailId] = React.useState<string | null>(null);
   const [detail, setDetail] = React.useState<SuperMuniDetail | null>(null);
   const [detailErr, setDetailErr] = React.useState<string | null>(null);
-
-  // #66 契約モーダル
-  const [contractId, setContractId] = React.useState<string | null>(null);
 
   const loadOverview = React.useCallback(() => {
     apiGet<Overview>("/api/super/overview")
@@ -151,7 +139,6 @@ export function SuperApp() {
             onAddMuni={() => setMuniModal(true)}
             onInvite={(m) => setInviteFor(m)}
             onOpenDetail={openDetail}
-            onOpenContract={setContractId}
           />
         )}
         {data && tab === "accounts" && <AccountsTab municipalities={data.municipalities} />}
@@ -178,18 +165,6 @@ export function SuperApp() {
           onClose={() => setDetailId(null)}
         />
       )}
-
-      {/* #66 契約モーダル */}
-      {contractId && (
-        <ContractModal
-          municipalityId={contractId}
-          onClose={() => setContractId(null)}
-          onSaved={() => {
-            loadOverview();
-            setContractId(null);
-          }}
-        />
-      )}
     </main>
   );
 }
@@ -201,13 +176,11 @@ function OverviewTab({
   onAddMuni,
   onInvite,
   onOpenDetail,
-  onOpenContract,
 }: {
   data: Overview;
   onAddMuni: () => void;
   onInvite: (m: { id: string; name: string }) => void;
   onOpenDetail: (id: string) => void;
-  onOpenContract: (id: string) => void;
 }) {
   return (
     <>
@@ -219,7 +192,7 @@ function OverviewTab({
       </div>
 
       <div className="mt-8 mb-3 flex items-center justify-between">
-        <h2 className="text-[13px] font-bold text-slate-700">契約自治体</h2>
+        <h2 className="text-[13px] font-bold text-slate-700">自治体</h2>
         <button
           onClick={onAddMuni}
           className="inline-flex items-center gap-1 rounded-lg bg-slate-900 px-3 py-1.5 text-[12px] font-bold text-white hover:bg-slate-800"
@@ -267,22 +240,13 @@ function OverviewTab({
                     >
                       <UserPlus className="h-3 w-3" /> 管理者を招待
                     </button>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onOpenContract(m.id);
-                      }}
-                      className="inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-[11px] text-slate-600 hover:bg-slate-100"
-                    >
-                      <FileText className="h-3 w-3" /> 契約
-                    </button>
                   </div>
                 </td>
               </tr>
             ))}
             {data.municipalities.length === 0 && (
               <tr>
-                <td colSpan={6} className="px-4 py-8 text-center text-slate-400">契約自治体がありません</td>
+                <td colSpan={6} className="px-4 py-8 text-center text-slate-400">自治体がありません</td>
               </tr>
             )}
           </tbody>
@@ -644,144 +608,6 @@ function AnalyticsTab() {
         </table>
       </div>
     </>
-  );
-}
-
-/* ---------------- 契約モーダル(#66) ---------------- */
-
-function ContractModal({
-  municipalityId,
-  onClose,
-  onSaved,
-}: {
-  municipalityId: string;
-  onClose: () => void;
-  onSaved: () => void;
-}) {
-  const [c, setC] = React.useState<ContractDTO | null>(null);
-  const [err, setErr] = React.useState<string | null>(null);
-  const [saving, setSaving] = React.useState(false);
-
-  React.useEffect(() => {
-    apiGet<ContractDTO>(`/api/super/municipalities/${municipalityId}/contract`)
-      .then(setC)
-      .catch(() => setErr("契約情報の取得に失敗しました"));
-  }, [municipalityId]);
-
-  async function save() {
-    if (!c) return;
-    setSaving(true);
-    setErr(null);
-    try {
-      await apiPatch<ContractDTO>(`/api/super/municipalities/${municipalityId}/contract`, {
-        plan: c.plan,
-        contractStatus: c.contractStatus,
-        annualBudget: c.annualBudget,
-        contractStart: c.contractStart || undefined,
-        contractEnd: c.contractEnd || undefined,
-      });
-      onSaved();
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : "保存に失敗しました");
-      setSaving(false);
-    }
-  }
-
-  return (
-    <div className="fixed inset-0 z-40 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-slate-900/30" onClick={onClose} />
-      <div className="relative z-50 w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow-xl">
-        {!c && !err && (
-          <div className="flex h-32 items-center justify-center gap-2 text-slate-500">
-            <Loader2 className="h-5 w-5 animate-spin" />
-            読み込み中…
-          </div>
-        )}
-        {err && <div className="mb-3 rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-[12px] text-red-700">{err}</div>}
-        {c && (
-          <>
-            <div className="mb-4 flex items-start justify-between">
-              <div className="text-[15px] font-bold">{c.name} の契約</div>
-              <button onClick={onClose} className="text-slate-400 hover:text-slate-900">
-                <X className="h-5 w-5" />
-              </button>
-            </div>
-
-            <label className="mb-3 block text-[12px] font-medium text-slate-600">
-              プラン
-              <select
-                value={c.plan}
-                onChange={(e) => setC({ ...c, plan: e.target.value as ContractDTO["plan"] })}
-                className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
-              >
-                {(Object.keys(PLAN_LABEL) as ContractDTO["plan"][]).map((p) => (
-                  <option key={p} value={p}>{PLAN_LABEL[p]}</option>
-                ))}
-              </select>
-            </label>
-
-            <label className="mb-3 block text-[12px] font-medium text-slate-600">
-              契約状態
-              <select
-                value={c.contractStatus}
-                onChange={(e) => setC({ ...c, contractStatus: e.target.value as ContractDTO["contractStatus"] })}
-                className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
-              >
-                {(Object.keys(STATUS_LABEL) as ContractDTO["contractStatus"][]).map((s) => (
-                  <option key={s} value={s}>{STATUS_LABEL[s]}</option>
-                ))}
-              </select>
-            </label>
-
-            <label className="mb-3 block text-[12px] font-medium text-slate-600">
-              年間活動費枠(円)
-              <input
-                type="number"
-                value={c.annualBudget}
-                min={0}
-                onChange={(e) => setC({ ...c, annualBudget: Number(e.target.value) })}
-                className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
-              />
-            </label>
-
-            <div className="mb-4 flex gap-3">
-              <label className="flex-1 text-[12px] font-medium text-slate-600">
-                契約開始
-                <input
-                  type="date"
-                  value={c.contractStart ?? ""}
-                  onChange={(e) => setC({ ...c, contractStart: e.target.value })}
-                  className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
-                />
-              </label>
-              <label className="flex-1 text-[12px] font-medium text-slate-600">
-                契約終了
-                <input
-                  type="date"
-                  value={c.contractEnd ?? ""}
-                  onChange={(e) => setC({ ...c, contractEnd: e.target.value })}
-                  className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
-                />
-              </label>
-            </div>
-
-            <div className="flex justify-end gap-2">
-              <button onClick={onClose} className="rounded-lg px-3 py-2 text-[13px] text-slate-500 hover:text-slate-900">
-                キャンセル
-              </button>
-              <button
-                onClick={save}
-                disabled={saving}
-                className="inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-4 py-2 text-[13px] font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
-              >
-                {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-                保存
-              </button>
-            </div>
-          </>
-        )}
-      </div>
-    </div>
   );
 }
 

--- a/src/lib/db/__tests__/super.test.ts
+++ b/src/lib/db/__tests__/super.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+
+// super(運営者)リポジトリ層のユニットテスト。
+// repos.test.ts の疎通パターンに倣い、sqlite シードに対して
+// 主要な運営操作(自治体作成 / admin 招待 / ユーザー削除 / 契約取得)を検証する。
+const SEED_MUNI = "muni_shinonsen"; // seed.ts の新温泉町
+
+describe("super.createMunicipality", () => {
+  it("自治体を新規作成し overview に反映される", async () => {
+    const before = (await sqliteRepos.super.overview()).totals.municipalities;
+    const created = await sqliteRepos.super.createMunicipality({ name: "テスト町", prefecture: "兵庫県" });
+
+    expect(created.id).toBeTruthy();
+    expect(created.name).toBe("テスト町");
+    expect(created.prefecture).toBe("兵庫県");
+
+    const after = await sqliteRepos.super.overview();
+    expect(after.totals.municipalities).toBe(before + 1);
+    expect(after.municipalities.map((m) => m.name)).toContain("テスト町");
+  });
+
+  it("annualBudget 未指定なら既定枠(200万円)で契約を取得できる", async () => {
+    const created = await sqliteRepos.super.createMunicipality({ name: "枠デフォ町", prefecture: "兵庫県" });
+    const contract = await sqliteRepos.super.getContract(created.id);
+    expect(contract?.annualBudget).toBe(2000000);
+  });
+});
+
+describe("super.createAdminInvite", () => {
+  it("admin を pre-provision し、招待トークンを発行する", async () => {
+    const muni = await sqliteRepos.super.createMunicipality({ name: "招待先町", prefecture: "兵庫県" });
+    const res = await sqliteRepos.super.createAdminInvite({
+      municipalityId: muni.id,
+      email: "admin@example.com",
+      name: "招待 太郎",
+      createdBy: "u_super",
+    });
+
+    // トークンと有効期限
+    expect(res.token).toMatch(/^[0-9a-f]{48}$/);
+    expect(new Date(res.expiresAt).getTime()).toBeGreaterThan(Date.now());
+
+    // /api/auth/me が email で紐づけられるよう users 行が先に作られている
+    const users = await sqliteRepos.super.listUsers({ municipalityId: muni.id, role: "admin" });
+    const admin = users.find((u) => u.email === "admin@example.com");
+    expect(admin).toBeDefined();
+    expect(admin?.role).toBe("admin");
+    expect(admin?.status).toBe("active");
+    expect(admin?.municipalityId).toBe(muni.id);
+  });
+});
+
+describe("super.deleteUser", () => {
+  it("ユーザーを削除すると一覧から消える", async () => {
+    const before = await sqliteRepos.super.listUsers({ municipalityId: SEED_MUNI, role: "member" });
+    expect(before.length).toBeGreaterThan(0);
+    const target = before[0];
+
+    await sqliteRepos.super.deleteUser(target.id);
+
+    const after = await sqliteRepos.super.listUsers({ municipalityId: SEED_MUNI, role: "member" });
+    expect(after.map((u) => u.id)).not.toContain(target.id);
+    expect(after.length).toBe(before.length - 1);
+  });
+});
+
+describe("super.getContract", () => {
+  it("契約未設定のシード自治体は既定値(year1 / trial)を返す", async () => {
+    const c = await sqliteRepos.super.getContract(SEED_MUNI);
+    expect(c).not.toBeNull();
+    expect(c?.municipalityId).toBe(SEED_MUNI);
+    expect(c?.plan).toBe("year1");
+    expect(c?.contractStatus).toBe("trial");
+  });
+
+  it("存在しない自治体 ID は null を返す", async () => {
+    const c = await sqliteRepos.super.getContract("muni_does_not_exist");
+    expect(c).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要
運営者(super)ダッシュボードの**契約・課金管理 UI を MVP から撤去**し、Phase 2(Year 2 以降)へ延期する。あわせて super リポジトリのユニットテストを追加。

## 対応 Issue
- Closes #72 契約ボタンで「契約情報の取得に失敗しました」になる
- Closes #73 契約・課金管理の仕様見直し・MVP から外す

## 変更点
### 契約 UI 撤去(`src/app/super/_app.tsx`)
- 自治体テーブルの「契約」ボタン、`ContractModal`、関連 state/import を削除
  → 本番で `契約情報の取得に失敗しました` が出る導線そのものを断つ(#72)
  → 契約・課金は課金体系が未確定のため MVP から除外(#73)
- 見出し「契約自治体」→「自治体」、空表示文言も同様
- **API ルート `/api/super/municipalities/[id]/contract` と Repos(`getContract`/`updateContract`)は温存** — Phase 2 は UI 復活のみで再利用可

### ADR 追加(`docs/30_contract_mvp_phase2.md`)
- 延期判断の根拠と Phase 2 復活手順を記録(ADR-30)

### ユニットテスト追加(`src/lib/db/__tests__/super.test.ts`)
- `createMunicipality` / `createAdminInvite`(admin pre-provision + 招待トークン)/ `deleteUser` / `getContract`(既定値・null)を検証

## 検証
- `npx tsc --noEmit` クリーン
- `npm test` → 2 files / 8 tests passed(既存2 + 新規6)

## スコープ外(別途)
- Playwright E2E(本リポジトリ未導入 + ログインが Supabase Magic Link のため要相談)

🤖 Generated with [Claude Code](https://claude.com/claude-code)