### PR TITLE
test(admin): #74 招待フロー回帰テスト + 根本原因の特定

### DIFF
--- a/src/app/api/admin/approval-routes.test.ts
+++ b/src/app/api/admin/approval-routes.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+
+// 承認ルート検証(受入団体ステップは団体必須)。
+// UI 側(RouteEditSheet.canSave / PR#75)は host_org ステップに
+// hostOrganizationId を必須化している。その入力がデータ層まで
+// 欠落なく往復することを検証する(団体必須の前提が壊れていないこと)。
+
+describe("承認ルート 受入団体ステップ (#PR75 整合)", () => {
+  it("host_org ステップの hostOrganizationId が保存・取得で保持される", async () => {
+    const org = await sqliteRepos.hostOrgs.upsert({ name: "テスト受入団体", kind: "npo" });
+    expect(org.id).toBeTruthy();
+
+    const created = await sqliteRepos.routes.create({
+      name: "受入団体ルート",
+      kind: "expense",
+      steps: [
+        { stepNo: 1, approverType: "host_org", approverLabel: "受入団体", hostOrganizationId: org.id },
+        { stepNo: 2, approverType: "dept", approverLabel: "企画課" },
+      ],
+    });
+    expect(created).toBeTruthy();
+
+    const fetched = (await sqliteRepos.routes.list()).find((r) => r.id === created!.id);
+    expect(fetched).toBeTruthy();
+
+    const hostStep = fetched!.steps.find((s) => s.approverType === "host_org");
+    expect(hostStep, "host_org ステップが消えている").toBeTruthy();
+    expect(hostStep!.hostOrganizationId).toBe(org.id);
+
+    const deptStep = fetched!.steps.find((s) => s.approverType === "dept");
+    expect(deptStep!.approverLabel).toBe("企画課");
+  });
+});

--- a/src/app/api/admin/invites/invites.test.ts
+++ b/src/app/api/admin/invites/invites.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+import { GET } from "./[token]/route";
+
+// #74 招待リンク回帰テスト。
+// 「管理者を招待」ボタンで発行したトークンが、発行→検証→単回使用まで
+// 期待どおり動くことを sqlite シードに対して検証する(AUTH_PROVIDER=none)。
+//
+// createdBy はシード済みユーザー(m1)を使う。本番(Postgres)では
+// created_by が users(id) への FK なので、実在ユーザーを渡す必要がある。
+const ADMIN_ID = "m1";
+
+function reqFor(token: string) {
+  return new Request(`http://localhost/api/admin/invites/${token}/`);
+}
+
+describe("invites リポジトリ (#74 招待発行)", () => {
+  it("create が トークン と 7 日後の有効期限を採番する", async () => {
+    const before = Date.now();
+    const { token, expiresAt } = await sqliteRepos.invites.create({
+      email: "newadmin@example.jp",
+      role: "admin",
+      municipalityName: "新温泉町",
+      createdBy: ADMIN_ID,
+    });
+    expect(token).toMatch(/^[0-9a-f]{48}$/); // 24 byte hex
+    const ms = new Date(expiresAt).getTime() - before;
+    // おおよそ 7 日(誤差 1 分許容)
+    expect(ms).toBeGreaterThan(7 * 24 * 60 * 60 * 1000 - 60_000);
+    expect(ms).toBeLessThan(7 * 24 * 60 * 60 * 1000 + 60_000);
+  });
+
+  it("findByToken が 発行時の email / role / 自治体名 を返す", async () => {
+    const { token } = await sqliteRepos.invites.create({
+      email: "staff@town.example.jp",
+      role: "manager",
+      municipalityName: "香美町",
+      createdBy: ADMIN_ID,
+    });
+    const row = await sqliteRepos.invites.findByToken(token);
+    expect(row).not.toBeNull();
+    expect(row!.email).toBe("staff@town.example.jp");
+    expect(row!.role).toBe("manager");
+    expect(row!.municipalityName).toBe("香美町");
+    expect(row!.usedAt).toBeNull();
+  });
+
+  it("findByToken は 未知のトークンに null を返す", async () => {
+    expect(await sqliteRepos.invites.findByToken("deadbeef")).toBeNull();
+  });
+
+  it("markUsed は usedAt を設定し、二重呼び出しでも冪等", async () => {
+    const { token } = await sqliteRepos.invites.create({
+      email: null,
+      role: "member",
+      municipalityName: "新温泉町",
+      createdBy: ADMIN_ID,
+    });
+    await sqliteRepos.invites.markUsed(token);
+    const used = await sqliteRepos.invites.findByToken(token);
+    expect(used!.usedAt).not.toBeNull();
+    const firstUsedAt = used!.usedAt;
+    // 二度目は no-op(used_at IS NULL 条件)。例外を投げず値も変えない。
+    await sqliteRepos.invites.markUsed(token);
+    const again = await sqliteRepos.invites.findByToken(token);
+    expect(again!.usedAt).toBe(firstUsedAt);
+  });
+});
+
+describe("GET /api/admin/invites/[token] (#74 トークン検証)", () => {
+  it("有効なトークンは 200 と招待情報を返す", async () => {
+    const { token } = await sqliteRepos.invites.create({
+      email: "ok@example.jp",
+      role: "admin",
+      municipalityName: "新温泉町",
+      createdBy: ADMIN_ID,
+    });
+    const res = await GET(reqFor(token), { params: Promise.resolve({ token }) });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      email: "ok@example.jp",
+      role: "admin",
+      municipalityName: "新温泉町",
+    });
+  });
+
+  it("未知のトークンは 404", async () => {
+    const res = await GET(reqFor("nope"), { params: Promise.resolve({ token: "nope" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("使用済みトークンは 410", async () => {
+    const { token } = await sqliteRepos.invites.create({
+      email: null,
+      role: "manager",
+      municipalityName: "新温泉町",
+      createdBy: ADMIN_ID,
+    });
+    await sqliteRepos.invites.markUsed(token);
+    const res = await GET(reqFor(token), { params: Promise.resolve({ token }) });
+    expect(res.status).toBe(410);
+  });
+});

--- a/src/app/api/budgets/budgets.test.ts
+++ b/src/app/api/budgets/budgets.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+import {
+  ANNUAL_BUDGET_TOTAL,
+  BUDGET_CATEGORIES,
+  DEFAULT_ALLOCATION,
+  currentFiscalYear,
+  defaultAllocationList,
+} from "@/lib/budget";
+
+// 予算枠配分の回帰テスト。
+// - 既定配分(defaultAllocationList)が年間総額に一致すること。
+// - 新規隊員を作成すると seedDefaultBudget により当年度の予算枠が
+//   既定配分どおりに自動投入されること。
+
+describe("予算 既定配分 (budget.ts)", () => {
+  it("既定配分の合計が年間総額(2,000,000)に一致する", () => {
+    const total = defaultAllocationList().reduce((s, a) => s + a.amountLimit, 0);
+    expect(ANNUAL_BUDGET_TOTAL).toBe(2_000_000);
+    expect(total).toBe(ANNUAL_BUDGET_TOTAL);
+  });
+
+  it("既定配分は全費目を網羅する", () => {
+    const cats = defaultAllocationList().map((a) => a.category);
+    expect(cats).toEqual([...BUDGET_CATEGORIES]);
+    for (const c of BUDGET_CATEGORIES) {
+      expect(DEFAULT_ALLOCATION[c]).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe("seedDefaultBudget (新規隊員作成時の予算枠自動投入)", () => {
+  it("members.upsert で作成した隊員に当年度の既定予算枠が入る", async () => {
+    const created = await sqliteRepos.members.upsert({
+      name: "予算 検証太郎",
+      role: "member",
+    });
+    expect(created.id).toBeTruthy();
+
+    const fy = currentFiscalYear();
+    const lines = await sqliteRepos.budgets.summaryByUser(created.id, fy);
+
+    // 費目ごとに既定配分の上限額が設定され、未使用(remaining=上限)であること。
+    for (const cat of BUDGET_CATEGORIES) {
+      const line = lines.find((l) => l.category === cat);
+      expect(line, `費目 ${cat} の予算行が無い`).toBeTruthy();
+      expect(line!.amountLimit).toBe(DEFAULT_ALLOCATION[cat] ?? 0);
+      expect(line!.used).toBe(0);
+      expect(line!.remaining).toBe(line!.amountLimit);
+    }
+
+    const total = lines.reduce((s, l) => s + l.amountLimit, 0);
+    expect(total).toBe(ANNUAL_BUDGET_TOTAL);
+  });
+});


### PR DESCRIPTION
## 概要
Issue #74「管理者を招待のリンクが無効になる」の調査。招待トークン層を再現検証し、回帰テストを追加。
**結論: トークンの発行/検証/単回使用は正しく動作している(#78 で Repos 化済み)。残る不具合は招待後のプロビジョニングにあり、共有/認証層の判断が必要。**

## やったこと(本 PR・編集範囲内のみ)
- `invites.test.ts` … 招待発行 / `findByToken`(email・role・自治体名)/ 未知トークン→null / `markUsed` 冪等、`GET /api/admin/invites/[token]`(200・404・410-used)
- `budgets.test.ts` … 既定配分の合計=年間総額(2,000,000)/ 新規隊員作成時の `seedDefaultBudget` 自動投入
- `approval-routes.test.ts` … host_org ステップの `hostOrganizationId` 往復保持(PR#75 整合)
- `npm test`: **13 passed**。`tsc --noEmit` 自分のファイルにエラーなし。
- ローカルスモーク(Chrome / `AUTH_PROVIDER=none`): `/signup?token=…` が招待バッジ付きで描画、`/admin` の6タブ + 隊員7名が表示されることを確認。

共有ファイル(repositories 等)は read-only import のみ。変更なし。

## #74 根本原因(コードで確認済み)
招待リンク自体は正常。問題は **招待後にログインできない** こと:
- `/api/auth/me` は `auth_id`→`email` で**既存の `public.users` 行に紐付けるだけ**(#64 で自動作成を廃止)。招待の role/自治体メタデータは消費しない。
- つまり招待が機能するには、**同じ email の users 行が事前に存在**している必要がある。
  - **役場職員(manager)**: `職員`タブ→`/api/staff`→`staff.upsert` が**実 email を保存** → 動作する ✅(admin が email を入力した場合)
  - **管理者(admin)**: admin の users 行を作る UI/API が**どこにも無い** → role=admin 招待は常に 403 → **これが #74**
  - **隊員(member)**: `members.upsert` が合成 email(`{id}@member.example.jp`)で作成 → 実 email と紐付かず 403(別の既知バグ。`/api/members` は本タスクの編集範囲外)

## 修正方針(要オーナー判断・共有/範囲外を含むため別 PR)
1. 招待発行時に email 必須化し、`public.users` 行を email リンク用に事前 upsert(共有リポジトリへの**追加**メソッド+自治体マッピング。要事前承認)
2. `/api/auth/me` が有効な招待トークンを消費して users 行を自動作成(認証層の変更=範囲外)
3. 招待タブを動作する role(職員)に限定し、admin/member は既存の登録フロー経由に統一(`admin/_app.tsx` のみ・範囲内だが機能削減=プロダクト判断)

🤖 Generated with [Claude Code](https://claude.com/claude-code)