### PR TITLE
release: super契約Phase2/manager ロスター/member 音声AI + テスト基盤 を本番へ

### DIFF
--- a/docs/30_contract_mvp_phase2.md
+++ b/docs/30_contract_mvp_phase2.md
@@ -1,0 +1,63 @@
+# ADR-30: 契約・課金管理機能は Phase 2 に延期(UI 撤去)
+
+**Status**: Decided (2026-07-01)
+**Related Issues**: #72(契約取得エラー)/ #73(仕様見直し・MVP から除外)/ #68(4機能実装)
+
+## Context
+
+PR #68 で運営者(super)ダッシュボードに4機能を実装した:
+
+1. ✅ 自治体ドリルダウン詳細
+2. ✅ アカウント/ロール管理
+3. ⚠️ **契約・課金管理** ← 本 ADR の対象
+4. ✅ 横断 KPI/分析
+
+本番で「契約」ボタンを押すと **「契約情報の取得に失敗しました」**(#72)になる。
+原因は契約用 `contract_*` カラムの本番スキーマ未適用 + 課金フロー(請求書・決済)が
+そもそも未実装で、「記録だけの半完成機能」が露出している状態だった。
+
+## Decision
+
+**契約・課金管理 UI を MVP から撤去し、Phase 2(Year 2 以降)に延期する。**
+
+### 実装内容(UI 撤去)
+
+`src/app/super/_app.tsx` から以下を削除:
+
+- 自治体テーブル各行の「契約」ボタン
+- 契約モーダル(`ContractModal` コンポーネント)とその呼び出し・state
+- 契約専用の型/ラベル import(`ContractDTO` / `PLAN_LABEL` / `STATUS_LABEL` / `FileText`)
+- 見出し「契約自治体」→「自治体」、空表示文言も同様に変更
+
+### 温存するもの(Phase 2 で再利用)
+
+- API ルート `src/app/api/super/municipalities/[id]/contract/route.ts`(GET/PATCH)
+- Repository メソッド(`getContract` / `updateContract`)と `ContractDTO` 型
+- migration の `contract_*` カラム定義
+
+→ サーバ側は無害(誰も叩かない)なので残置。Phase 2 は UI を復活させるだけ。
+
+## Rationale
+
+1. **#72 の即時解消**: ボタンが無ければエラーも出ない。本番 UX を直ちに改善。
+2. **MVP スコープの明確化**: 契約・課金は「自社の台帳」であり、隊員・自治体ユーザー
+   への直接価値が薄い。課金体系は Year 2 の県共同調達確定後に最適化する(#73)。
+3. **複雑性の削減**: 残り3機能(ドリルダウン/アカウント/KPI)で運営側は十分機能する。
+
+## Alternatives Considered
+
+| 案 | 評価 |
+|---|---|
+| そのまま残す(ボタン+エラー表示) | ❌ UX 最悪、バグレポート増 |
+| コメントアウトで温存 | ⚠️ 未使用 import/コンポーネントが lint を汚す |
+| **UI 撤去 + API/Repos 温存(採用)** | ✅ build クリーン、Phase 2 は git 履歴から復活容易 |
+
+## Phase 2 復活手順
+
+1. 本 PR を `git revert` するか、`git show <this-commit>:src/app/super/_app.tsx` で
+   契約 UI 差分を参照して `_app.tsx` に再導入。
+2. 本番に `contract_*` カラムの migration を適用。
+3. 請求書発行・決済 API を新規実装(本 MVP では未着手)。
+4. テスト・デプロイ。
+
+API ルートと Repository は無変更で使い回せる。

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,9 @@
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.17",
         "tsx": "^4.19.2",
-        "typescript": "^5.7.2"
+        "typescript": "^5.7.2",
+        "vite-tsconfig-paths": "^6.1.1",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -910,21 +912,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -932,9 +934,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2339,6 +2341,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -4051,6 +4063,289 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -4177,6 +4472,13 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.103.3",
@@ -4313,9 +4615,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4323,10 +4625,28 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -4959,6 +5279,119 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -5265,6 +5698,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -5542,6 +5985,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -5866,8 +6319,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -6045,6 +6498,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -6585,6 +7045,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6602,6 +7072,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -7021,6 +7501,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -7800,6 +8287,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -7871,6 +8619,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7966,9 +8724,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -8312,6 +9070,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -8434,6 +9206,13 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8481,9 +9260,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",
@@ -8500,7 +9279,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8941,6 +9720,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.137.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.3",
+        "@rolldown/binding-darwin-arm64": "1.1.3",
+        "@rolldown/binding-darwin-x64": "1.1.3",
+        "@rolldown/binding-freebsd-x64": "1.1.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+        "@rolldown/binding-linux-arm64-musl": "1.1.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-musl": "1.1.3",
+        "@rolldown/binding-openharmony-arm64": "1.1.3",
+        "@rolldown/binding-wasm32-wasi": "1.1.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+        "@rolldown/binding-win32-x64-msvc": "1.1.3"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9231,6 +10044,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -9254,6 +10074,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -9618,10 +10452,27 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -9663,6 +10514,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -9699,6 +10560,28 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "deprecated": "unmaintained",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -10027,6 +10910,215 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
+      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
+      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -10155,6 +11247,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "typecheck": "tsc --noEmit",
     "typecheck:op": "node scripts/op-run.mjs .env.1password.local npm run typecheck",
     "db:reset": "rm -rf .data",
-    "db:migrate": "tsx scripts/apply-migrations.ts"
+    "db:migrate": "tsx scripts/apply-migrations.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.1",
@@ -64,6 +66,8 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vite-tsconfig-paths": "^6.1.1",
+    "vitest": "^4.1.9"
   }
 }

--- a/src/app/api/announcements/__tests__/post-authz.test.ts
+++ b/src/app/api/announcements/__tests__/post-authz.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// お知らせ配信(POST /api/announcements)の認可・なりすまし回帰テスト(PR #77)。
+// 配信は役場職員のみ。senderId/senderName は body を信用せずセッションから確定する。
+
+function reqPost(body: unknown) {
+  return new Request("http://test/api/announcements", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function post(role: string, devUserId: string, body: unknown) {
+  vi.resetModules();
+  vi.stubEnv("AUTH_PROVIDER", "none");
+  vi.stubEnv("DEV_USER_ROLE", role);
+  vi.stubEnv("DEV_USER_ID", devUserId);
+  const mod = await import("../route");
+  const res = await mod.POST(reqPost(body));
+  return { status: res.status, json: await res.json() };
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("POST /api/announcements 配信認可(#77 回帰)", () => {
+  it("member は役場名義で配信できない(403)", async () => {
+    const r = await post("member", "m1", { body: "勝手なお知らせ" });
+    expect(r.status).toBe(403);
+  });
+
+  it("manager でも本文が空なら 400", async () => {
+    const r = await post("manager", "s1", { body: "   " });
+    expect(r.status).toBe(400);
+  });
+
+  it("manager の配信は senderId/senderName を body ではなくセッションから確定する", async () => {
+    const r = await post("manager", "s1", {
+      body: "6 月例会の議題について",
+      senderId: "HACKER",
+      senderName: "なりすまし",
+    });
+    expect(r.status).toBe(201);
+    // body で渡した偽の senderName は無視され、セッションの s1(谷本 拓海)が記録される。
+    expect(r.json.sender).toBe("谷本 拓海");
+  });
+});

--- a/src/app/api/approvals/[id]/decide/__tests__/decide-authz.test.ts
+++ b/src/app/api/approvals/[id]/decide/__tests__/decide-authz.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// 承認/差戻し(decide)の認可ガード回帰テスト(PR #77)。
+// 役場職員(manager/admin)以外の自己承認・無権限承認を遮断していることを保証する。
+// AUTH_PROVIDER=none + DEV_USER_ROLE 切替で各ロールになりすます(vitest.config 参照)。
+
+function reqPost(body: unknown) {
+  return new Request("http://test/api/approvals/x/decide", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ロールを切り替えて route を再評価する(auth.ts は import 時に DEV_USER_ROLE を捕捉するため)。
+async function decide(role: string, id: string, body: unknown) {
+  vi.resetModules();
+  vi.stubEnv("AUTH_PROVIDER", "none");
+  vi.stubEnv("DEV_USER_ROLE", role);
+  vi.stubEnv("DEV_USER_ID", role === "member" ? "m1" : "s1");
+  const mod = await import("../route");
+  const res = await mod.POST(reqPost(body), { params: Promise.resolve({ id }) });
+  return { status: res.status, json: await res.json() };
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("POST /api/approvals/[id]/decide 認可ガード(#77 回帰)", () => {
+  it("member は承認できない(自己承認・無権限承認を 403 で遮断)", async () => {
+    const r = await decide("member", "a1", { action: "approve" });
+    expect(r.status).toBe(403);
+    expect(r.json.error).toContain("承認権限");
+  });
+
+  it("member はロールゲートで弾かれ、存在しない id でも DB 参照前に 403", async () => {
+    const r = await decide("member", "no-such-id", { action: "approve" });
+    expect(r.status).toBe(403);
+  });
+
+  it("manager は承認できる(多段ルートは次ステップへ前進し pending 継続)", async () => {
+    // a4: 担当課 → 受入団体 → 企画課 の 3 段、current_step=0。
+    const r = await decide("manager", "a4", { action: "approve" });
+    expect(r.status).toBe(200);
+    expect(r.json.result).toBe("pending");
+  });
+
+  it("manager の最終承認で approved になり、再処理は 409", async () => {
+    // a2: 最終ステップが pending(current_step=1)。1 回承認で確定。
+    const first = await decide("manager", "a2", { action: "approve" });
+    expect(first.status).toBe(200);
+    expect(first.json.result).toBe("approved");
+
+    const again = await decide("manager", "a2", { action: "approve" });
+    expect(again.status).toBe(409);
+  });
+
+  it("manager の差戻しは理由 5 文字未満で 400、妥当な理由で rejected", async () => {
+    const tooShort = await decide("manager", "a3", { action: "reject", comment: "x" });
+    expect(tooShort.status).toBe(400);
+
+    const ok = await decide("manager", "a3", { action: "reject", comment: "添付不足のため差戻します" });
+    expect(ok.status).toBe(200);
+    expect(ok.json.result).toBe("rejected");
+  });
+});

--- a/src/app/api/monthly-reports/__tests__/list-authz.test.ts
+++ b/src/app/api/monthly-reports/__tests__/list-authz.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// 月報一覧(GET /api/monthly-reports)の閲覧スコープ回帰テスト(PR #79)。
+// 既定は本人の月報。?userId で他人の月報を引けるのは役場職員(manager/admin)のみ。
+
+async function getList(role: string, devUserId: string, qUserId?: string) {
+  vi.resetModules();
+  vi.stubEnv("AUTH_PROVIDER", "none");
+  vi.stubEnv("DEV_USER_ROLE", role);
+  vi.stubEnv("DEV_USER_ID", devUserId);
+  const mod = await import("../route");
+  const url = qUserId
+    ? `http://test/api/monthly-reports?userId=${qUserId}`
+    : "http://test/api/monthly-reports";
+  const res = await mod.GET(new Request(url));
+  return { status: res.status, json: await res.json() };
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("GET /api/monthly-reports 閲覧スコープ(#79 回帰)", () => {
+  it("member は他人の userId を指定すると 403", async () => {
+    const r = await getList("member", "m2", "m1");
+    expect(r.status).toBe(403);
+  });
+
+  it("manager は担当隊員(m1)の月報を ?userId で閲覧できる", async () => {
+    // m1(田中 あかり)はシードに月報あり。s1 は manager。
+    const r = await getList("manager", "s1", "m1");
+    expect(r.status).toBe(200);
+    expect(Array.isArray(r.json)).toBe(true);
+    expect(r.json.length).toBeGreaterThan(0);
+  });
+
+  it("member は userId 未指定なら自分(m1)の月報を取得できる", async () => {
+    const r = await getList("member", "m1");
+    expect(r.status).toBe(200);
+    expect(Array.isArray(r.json)).toBe(true);
+    expect(r.json.length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/manager/_app.tsx
+++ b/src/app/manager/_app.tsx
@@ -416,6 +416,13 @@ export function ManagerApp() {
         const ms = await apiGet<MemberDTO[]>("/api/members");
         const mapped: Member[] = ms.map((m) => ({ id: m.id, name: m.name, role: m.role, initials: initialsOf(m.name) }));
         setMembers(mapped);
+        // 実データの隊員を既定の担当・配信先に反映(モック名のままだとロスター/配信先が空になる)。
+        // PoC では自治体の全隊員を担当として表示し、設定で絞り込み可能にする。
+        const memberNames = mapped.map((m) => m.name);
+        if (memberNames.length) {
+          setManaged(memberNames);
+          setNoticeTargets(memberNames);
+        }
         const entries = await Promise.all(
           mapped.map(async (m) => {
             try {
@@ -1655,7 +1662,7 @@ function NoticeDetailSheet({ notice, onClose }: { notice: NoticeItem; onClose: (
 }
 
 function SettingsSheet({ onClose }: { onClose: () => void }) {
-  const { managed, setManaged } = useApp();
+  const { managed, setManaged, members } = useApp();
   const [local, setLocal] = React.useState<string[]>(managed);
 
   function toggle(name: string) {
@@ -1686,10 +1693,10 @@ function SettingsSheet({ onClose }: { onClose: () => void }) {
         </p>
 
         <ul className="mt-3 space-y-px">
-          {ALL_MEMBERS.map((m) => {
+          {members.map((m) => {
             const on = local.includes(m.name);
             return (
-              <li key={m.name}>
+              <li key={m.id}>
                 <button
                   onClick={() => toggle(m.name)}
                   className="flex w-full items-center gap-3 border-b border-slate-100 py-2.5 text-left hover:bg-slate-50"

--- a/src/app/member/_app.tsx
+++ b/src/app/member/_app.tsx
@@ -116,9 +116,19 @@ async function uploadReceipt(file: File): Promise<{ key: string; url: string } |
 }
 
 // Web Speech API による音声入力(クライアント完結・インフラ不要)。非対応ブラウザでは非表示。
+// 実機での失敗(マイク不許可・無音・通信)を黙殺せず、ボタン上に短いラベルで可視化する。
+const SR_ERROR_LABEL: Record<string, string> = {
+  "not-allowed": "マイク許可が必要",
+  "service-not-allowed": "マイク許可が必要",
+  "no-speech": "聞き取れません",
+  "audio-capture": "マイク未検出",
+  network: "通信エラー",
+};
+
 function VoiceInput({ onText, className }: { onText: (t: string) => void; className?: string }) {
   const [supported, setSupported] = React.useState(false);
   const [listening, setListening] = React.useState(false);
+  const [errLabel, setErrLabel] = React.useState<string | null>(null);
   const recRef = React.useRef<{ stop: () => void } | null>(null);
 
   React.useEffect(() => {
@@ -134,10 +144,11 @@ function VoiceInput({ onText, className }: { onText: (t: string) => void; classN
       recRef.current?.stop();
       return;
     }
+    setErrLabel(null);
     const rec = new SR() as {
       lang: string; interimResults: boolean; continuous: boolean;
       onresult: (e: { results: ArrayLike<ArrayLike<{ transcript: string }>> }) => void;
-      onend: () => void; onerror: () => void; start: () => void; stop: () => void;
+      onend: () => void; onerror: (e: { error?: string }) => void; start: () => void; stop: () => void;
     };
     rec.lang = "ja-JP";
     rec.interimResults = false;
@@ -147,26 +158,36 @@ function VoiceInput({ onText, className }: { onText: (t: string) => void; classN
       if (text) onText(text);
     };
     rec.onend = () => setListening(false);
-    rec.onerror = () => setListening(false);
+    rec.onerror = (e) => {
+      setListening(false);
+      setErrLabel(SR_ERROR_LABEL[e?.error ?? ""] ?? "音声エラー");
+    };
     recRef.current = rec;
     setListening(true);
-    rec.start();
+    try {
+      rec.start();
+    } catch {
+      // start() は連打などで InvalidStateError を投げることがある。状態だけ戻す。
+      setListening(false);
+    }
   }
 
   if (!supported) return null;
+  const isError = !!errLabel && !listening;
   return (
     <button
       type="button"
       onClick={toggle}
+      title={errLabel ?? undefined}
       className={
         className ??
         `inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[14px] font-semibold transition ${
-          listening ? "border-rose-500 bg-rose-50 text-rose-700" : "border-slate-300 bg-white text-slate-700 hover:border-slate-900 hover:bg-slate-50"
+          listening || isError ? "border-rose-500 bg-rose-50 text-rose-700" : "border-slate-300 bg-white text-slate-700 hover:border-slate-900 hover:bg-slate-50"
         }`
       }
     >
       <Mic className="h-3 w-3" />
-      {listening ? "聞き取り中…" : "音声"}
+      {listening ? "聞き取り中…" : errLabel ?? "音声"}
     </button>
   );
 }
@@ -1391,13 +1412,17 @@ function ActivityFieldset({ value, onChange }: { value: InlineActivity; onChange
   // AI 質問補完(P0-2): メモから「次の一問」を取得して表示
   const [followupQ, setFollowupQ] = React.useState<string | null>(null);
   const [loadingQ, setLoadingQ] = React.useState(false);
+  const [qErr, setQErr] = React.useState(false);
   async function askFollowup() {
     setLoadingQ(true);
+    setQErr(false);
     try {
       const r = await apiPost<{ question: string }>("/api/ai/followup", { current: value.body });
       if (r.question) setFollowupQ(r.question);
+      else setQErr(true);
     } catch {
-      /* noop */
+      // 実機で AI 接続に失敗した場合(プロバイダ未設定/停止 等)を黙殺せず可視化する。
+      setQErr(true);
     } finally {
       setLoadingQ(false);
     }
@@ -1433,6 +1458,11 @@ function ActivityFieldset({ value, onChange }: { value: InlineActivity; onChange
         <div className="mt-1 flex items-start gap-1.5 rounded-lg bg-amber-50 px-2.5 py-1.5 text-[13px] text-amber-900">
           <Lightbulb className="mt-0.5 h-3.5 w-3.5 shrink-0" />
           <span>{followupQ}</span>
+        </div>
+      )}
+      {qErr && (
+        <div className="mt-1 rounded-lg bg-rose-50 px-2.5 py-1.5 text-[13px] text-rose-700">
+          AI に接続できませんでした。時間をおいて再度お試しください。
         </div>
       )}
     </>

--- a/src/app/super/_app.tsx
+++ b/src/app/super/_app.tsx
@@ -17,19 +17,18 @@ import {
   ClipboardCheck,
   TrendingUp,
   TrendingDown,
-  FileText,
 } from "lucide-react";
 import type {
   SuperMuniDetail,
   SuperUserRow,
-  ContractDTO,
   SuperAnalytics,
 } from "@/lib/db/repositories/types";
 
 /* ============================================================
    super 運営者ダッシュボード(#64 / #65 / #66)
    全自治体横断のサマリ + 自治体作成・admin 招待オンボーディング(#65)
-   + 自治体ドリルダウン・アカウント管理・契約管理・分析(#66)。
+   + 自治体ドリルダウン・アカウント管理・分析(#66)。
+   ※ 契約・課金管理 UI は Phase 2 へ延期(#72/#73, ADR-30)。API/Repos は温存。
    super ロールのみアクセス可。
    ============================================================ */
 
@@ -49,14 +48,6 @@ type Overview = {
 
 type Tab = "overview" | "accounts" | "analytics";
 
-const PLAN_LABEL: Record<ContractDTO["plan"], string> = { year1: "Year1", year2: "Year2", year3: "Year3" };
-const STATUS_LABEL: Record<ContractDTO["contractStatus"], string> = {
-  trial: "トライアル",
-  active: "契約中",
-  suspended: "停止",
-  ended: "終了",
-};
-
 export function SuperApp() {
   const [data, setData] = React.useState<Overview | null>(null);
   const [error, setError] = React.useState<string | null>(null);
@@ -70,9 +61,6 @@ export function SuperApp() {
   const [detailId, setDetailId] = React.useState<string | null>(null);
   const [detail, setDetail] = React.useState<SuperMuniDetail | null>(null);
   const [detailErr, setDetailErr] = React.useState<string | null>(null);
-
-  // #66 契約モーダル
-  const [contractId, setContractId] = React.useState<string | null>(null);
 
   const loadOverview = React.useCallback(() => {
     apiGet<Overview>("/api/super/overview")
@@ -151,7 +139,6 @@ export function SuperApp() {
             onAddMuni={() => setMuniModal(true)}
             onInvite={(m) => setInviteFor(m)}
             onOpenDetail={openDetail}
-            onOpenContract={setContractId}
           />
         )}
         {data && tab === "accounts" && <AccountsTab municipalities={data.municipalities} />}
@@ -178,18 +165,6 @@ export function SuperApp() {
           onClose={() => setDetailId(null)}
         />
       )}
-
-      {/* #66 契約モーダル */}
-      {contractId && (
-        <ContractModal
-          municipalityId={contractId}
-          onClose={() => setContractId(null)}
-          onSaved={() => {
-            loadOverview();
-            setContractId(null);
-          }}
-        />
-      )}
     </main>
   );
 }
@@ -201,13 +176,11 @@ function OverviewTab({
   onAddMuni,
   onInvite,
   onOpenDetail,
-  onOpenContract,
 }: {
   data: Overview;
   onAddMuni: () => void;
   onInvite: (m: { id: string; name: string }) => void;
   onOpenDetail: (id: string) => void;
-  onOpenContract: (id: string) => void;
 }) {
   return (
     <>
@@ -219,7 +192,7 @@ function OverviewTab({
       </div>
 
       <div className="mt-8 mb-3 flex items-center justify-between">
-        <h2 className="text-[13px] font-bold text-slate-700">契約自治体</h2>
+        <h2 className="text-[13px] font-bold text-slate-700">自治体</h2>
         <button
           onClick={onAddMuni}
           className="inline-flex items-center gap-1 rounded-lg bg-slate-900 px-3 py-1.5 text-[12px] font-bold text-white hover:bg-slate-800"
@@ -267,22 +240,13 @@ function OverviewTab({
                     >
                       <UserPlus className="h-3 w-3" /> 管理者を招待
                     </button>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onOpenContract(m.id);
-                      }}
-                      className="inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-[11px] text-slate-600 hover:bg-slate-100"
-                    >
-                      <FileText className="h-3 w-3" /> 契約
-                    </button>
                   </div>
                 </td>
               </tr>
             ))}
             {data.municipalities.length === 0 && (
               <tr>
-                <td colSpan={6} className="px-4 py-8 text-center text-slate-400">契約自治体がありません</td>
+                <td colSpan={6} className="px-4 py-8 text-center text-slate-400">自治体がありません</td>
               </tr>
             )}
           </tbody>
@@ -644,144 +608,6 @@ function AnalyticsTab() {
         </table>
       </div>
     </>
-  );
-}
-
-/* ---------------- 契約モーダル(#66) ---------------- */
-
-function ContractModal({
-  municipalityId,
-  onClose,
-  onSaved,
-}: {
-  municipalityId: string;
-  onClose: () => void;
-  onSaved: () => void;
-}) {
-  const [c, setC] = React.useState<ContractDTO | null>(null);
-  const [err, setErr] = React.useState<string | null>(null);
-  const [saving, setSaving] = React.useState(false);
-
-  React.useEffect(() => {
-    apiGet<ContractDTO>(`/api/super/municipalities/${municipalityId}/contract`)
-      .then(setC)
-      .catch(() => setErr("契約情報の取得に失敗しました"));
-  }, [municipalityId]);
-
-  async function save() {
-    if (!c) return;
-    setSaving(true);
-    setErr(null);
-    try {
-      await apiPatch<ContractDTO>(`/api/super/municipalities/${municipalityId}/contract`, {
-        plan: c.plan,
-        contractStatus: c.contractStatus,
-        annualBudget: c.annualBudget,
-        contractStart: c.contractStart || undefined,
-        contractEnd: c.contractEnd || undefined,
-      });
-      onSaved();
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : "保存に失敗しました");
-      setSaving(false);
-    }
-  }
-
-  return (
-    <div className="fixed inset-0 z-40 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-slate-900/30" onClick={onClose} />
-      <div className="relative z-50 w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow-xl">
-        {!c && !err && (
-          <div className="flex h-32 items-center justify-center gap-2 text-slate-500">
-            <Loader2 className="h-5 w-5 animate-spin" />
-            読み込み中…
-          </div>
-        )}
-        {err && <div className="mb-3 rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-[12px] text-red-700">{err}</div>}
-        {c && (
-          <>
-            <div className="mb-4 flex items-start justify-between">
-              <div className="text-[15px] font-bold">{c.name} の契約</div>
-              <button onClick={onClose} className="text-slate-400 hover:text-slate-900">
-                <X className="h-5 w-5" />
-              </button>
-            </div>
-
-            <label className="mb-3 block text-[12px] font-medium text-slate-600">
-              プラン
-              <select
-                value={c.plan}
-                onChange={(e) => setC({ ...c, plan: e.target.value as ContractDTO["plan"] })}
-                className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
-              >
-                {(Object.keys(PLAN_LABEL) as ContractDTO["plan"][]).map((p) => (
-                  <option key={p} value={p}>{PLAN_LABEL[p]}</option>
-                ))}
-              </select>
-            </label>
-
-            <label className="mb-3 block text-[12px] font-medium text-slate-600">
-              契約状態
-              <select
-                value={c.contractStatus}
-                onChange={(e) => setC({ ...c, contractStatus: e.target.value as ContractDTO["contractStatus"] })}
-                className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
-              >
-                {(Object.keys(STATUS_LABEL) as ContractDTO["contractStatus"][]).map((s) => (
-                  <option key={s} value={s}>{STATUS_LABEL[s]}</option>
-                ))}
-              </select>
-            </label>
-
-            <label className="mb-3 block text-[12px] font-medium text-slate-600">
-              年間活動費枠(円)
-              <input
-                type="number"
-                value={c.annualBudget}
-                min={0}
-                onChange={(e) => setC({ ...c, annualBudget: Number(e.target.value) })}
-                className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
-              />
-            </label>
-
-            <div className="mb-4 flex gap-3">
-              <label className="flex-1 text-[12px] font-medium text-slate-600">
-                契約開始
-                <input
-                  type="date"
-                  value={c.contractStart ?? ""}
-                  onChange={(e) => setC({ ...c, contractStart: e.target.value })}
-                  className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
-                />
-              </label>
-              <label className="flex-1 text-[12px] font-medium text-slate-600">
-                契約終了
-                <input
-                  type="date"
-                  value={c.contractEnd ?? ""}
-                  onChange={(e) => setC({ ...c, contractEnd: e.target.value })}
-                  className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px]"
-                />
-              </label>
-            </div>
-
-            <div className="flex justify-end gap-2">
-              <button onClick={onClose} className="rounded-lg px-3 py-2 text-[13px] text-slate-500 hover:text-slate-900">
-                キャンセル
-              </button>
-              <button
-                onClick={save}
-                disabled={saving}
-                className="inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-4 py-2 text-[13px] font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
-              >
-                {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-                保存
-              </button>
-            </div>
-          </>
-        )}
-      </div>
-    </div>
   );
 }
 

--- a/src/lib/db/__tests__/repos.test.ts
+++ b/src/lib/db/__tests__/repos.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+
+// テスト基盤の疎通確認(サンプル)。
+// sqlite シードに対してリポジトリ層が期待どおり読めることを検証する。
+// 各ロールはこのパターンを真似て、自分のドメインのテストを追加する。
+describe("sqliteRepos (seed 疎通)", () => {
+  it("members.list() がシードの隊員を返す", async () => {
+    const members = await sqliteRepos.members.list();
+    expect(members.length).toBeGreaterThanOrEqual(7);
+    expect(members.map((m) => m.name)).toContain("田中 あかり");
+  });
+
+  it("users.count() が 0 より大きい(シード投入済み)", async () => {
+    const n = await sqliteRepos.users.count();
+    expect(n).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/db/__tests__/super.test.ts
+++ b/src/lib/db/__tests__/super.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+
+// super(運営者)リポジトリ層のユニットテスト。
+// repos.test.ts の疎通パターンに倣い、sqlite シードに対して
+// 主要な運営操作(自治体作成 / admin 招待 / ユーザー削除 / 契約取得)を検証する。
+const SEED_MUNI = "muni_shinonsen"; // seed.ts の新温泉町
+
+describe("super.createMunicipality", () => {
+  it("自治体を新規作成し overview に反映される", async () => {
+    const before = (await sqliteRepos.super.overview()).totals.municipalities;
+    const created = await sqliteRepos.super.createMunicipality({ name: "テスト町", prefecture: "兵庫県" });
+
+    expect(created.id).toBeTruthy();
+    expect(created.name).toBe("テスト町");
+    expect(created.prefecture).toBe("兵庫県");
+
+    const after = await sqliteRepos.super.overview();
+    expect(after.totals.municipalities).toBe(before + 1);
+    expect(after.municipalities.map((m) => m.name)).toContain("テスト町");
+  });
+
+  it("annualBudget 未指定なら既定枠(200万円)で契約を取得できる", async () => {
+    const created = await sqliteRepos.super.createMunicipality({ name: "枠デフォ町", prefecture: "兵庫県" });
+    const contract = await sqliteRepos.super.getContract(created.id);
+    expect(contract?.annualBudget).toBe(2000000);
+  });
+});
+
+describe("super.createAdminInvite", () => {
+  it("admin を pre-provision し、招待トークンを発行する", async () => {
+    const muni = await sqliteRepos.super.createMunicipality({ name: "招待先町", prefecture: "兵庫県" });
+    const res = await sqliteRepos.super.createAdminInvite({
+      municipalityId: muni.id,
+      email: "admin@example.com",
+      name: "招待 太郎",
+      createdBy: "u_super",
+    });
+
+    // トークンと有効期限
+    expect(res.token).toMatch(/^[0-9a-f]{48}$/);
+    expect(new Date(res.expiresAt).getTime()).toBeGreaterThan(Date.now());
+
+    // /api/auth/me が email で紐づけられるよう users 行が先に作られている
+    const users = await sqliteRepos.super.listUsers({ municipalityId: muni.id, role: "admin" });
+    const admin = users.find((u) => u.email === "admin@example.com");
+    expect(admin).toBeDefined();
+    expect(admin?.role).toBe("admin");
+    expect(admin?.status).toBe("active");
+    expect(admin?.municipalityId).toBe(muni.id);
+  });
+});
+
+describe("super.deleteUser", () => {
+  it("ユーザーを削除すると一覧から消える", async () => {
+    const before = await sqliteRepos.super.listUsers({ municipalityId: SEED_MUNI, role: "member" });
+    expect(before.length).toBeGreaterThan(0);
+    const target = before[0];
+
+    await sqliteRepos.super.deleteUser(target.id);
+
+    const after = await sqliteRepos.super.listUsers({ municipalityId: SEED_MUNI, role: "member" });
+    expect(after.map((u) => u.id)).not.toContain(target.id);
+    expect(after.length).toBe(before.length - 1);
+  });
+});
+
+describe("super.getContract", () => {
+  it("契約未設定のシード自治体は既定値(year1 / trial)を返す", async () => {
+    const c = await sqliteRepos.super.getContract(SEED_MUNI);
+    expect(c).not.toBeNull();
+    expect(c?.municipalityId).toBe(SEED_MUNI);
+    expect(c?.plan).toBe("year1");
+    expect(c?.contractStatus).toBe("trial");
+  });
+
+  it("存在しない自治体 ID は null を返す", async () => {
+    const c = await sqliteRepos.super.getContract("muni_does_not_exist");
+    expect(c).toBeNull();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+// ユニットテスト基盤。
+// - sqlite(node:sqlite) + シードに対してリポジトリ/ロジック層を検証する。
+// - AUTH_PROVIDER=none で固定の開発ユーザーになりすませるため実アカウント不要。
+// - 各ロールは DEV_USER_ROLE を切り替えて自分のドメインを検証する。
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "node",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
+    env: {
+      AUTH_PROVIDER: "none",
+      DB_PROVIDER: "sqlite",
+      // .data 配下はリポジトリ管理外(.gitignore)。テスト専用DBを使う。
+      DATABASE_PATH: ".data/test-vitest.db",
+    },
+    // node:sqlite 等の重い初期化を考慮し直列実行(共有DBファイルの競合回避)。
+    fileParallelism: false,
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,11 @@
+import { rmSync } from "node:fs";
+
+// 各テスト実行の前にテスト専用 sqlite を破棄し、毎回まっさらなシード状態から始める。
+// getDb() は users が空のとき seed() を投入するため、削除→初回アクセスで再シードされる。
+for (const suffix of ["", "-shm", "-wal"]) {
+  try {
+    rmSync(`.data/test-vitest.db${suffix}`, { force: true });
+  } catch {
+    /* 存在しなければ無視 */
+  }
+}


### PR DESCRIPTION
## 概要
develop の最新を本番(main)へリリース。

## 含まれる主な変更
- **テスト基盤**: vitest 導入（17ファイル/58テスト green）
- **super**: ユーザー削除機能 / 契約・課金UIをMVPから撤去しPhase2へ延期(#72/#73)
- **manager**: 担当隊員ロスターを実データ化 / 役場API認可の回帰テスト(#77/#79)
- **member**: 音声入力/AI質問補完の失敗を可視化

## 検証
- develop で `npm test` 全58件 green
- Workers Builds の fail は既存の無関係エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)