### PR TITLE
fix(manager): 役場APIのローカル自治体IDフォールバックを seed に整合(H5)

### DIFF
--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -5,7 +5,10 @@ import { requireAppUser } from "@/lib/api/auth";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
+// ローカル sqlite のフォールバックは seed/sqlite の自治体 id("muni_shinonsen")に合わせる。
+// 以前は UUID 既定で、env 未設定のローカル開発だとお知らせが seed と別自治体になり空表示だった(H5)。
+// 本番(Supabase)は NEXT_PUBLIC_DEMO_MUNI_ID を設定するためこの既定は使われない。
+const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "muni_shinonsen";
 
 // お知らせ閲覧はログイン必須(隊員も自町のお知らせを読む)。未認証アクセスを遮断。
 export async function GET(req: Request) {

--- a/src/app/api/approvals/route.ts
+++ b/src/app/api/approvals/route.ts
@@ -5,7 +5,10 @@ import { requireAppUser } from "@/lib/api/auth";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
+// ローカル sqlite のフォールバックは seed/sqlite の自治体 id("muni_shinonsen")に合わせる。
+// 以前は UUID 既定で、env 未設定のローカル開発だと承認キューが seed と別自治体になり空表示だった(H5)。
+// 本番(Supabase)は NEXT_PUBLIC_DEMO_MUNI_ID を設定するためこの既定は使われない。
+const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "muni_shinonsen";
 
 // 進行中(pending)の承認のみ返す。完了/差戻しはキューから外れる。
 // 承認キューは役場職員(manager/admin)のみ閲覧可。未認証アクセスを遮断。

--- a/src/app/api/monthly-reports/route.ts
+++ b/src/app/api/monthly-reports/route.ts
@@ -6,7 +6,10 @@ import { requireAppUser } from "@/lib/api/auth";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
+// ローカル sqlite のフォールバックは seed/sqlite の自治体 id("muni_shinonsen")に合わせる。
+// 以前は UUID 既定で、env 未設定のローカル開発だと提出月報の承認キューが seed と別自治体になり空表示だった(H5)。
+// 本番(Supabase)は NEXT_PUBLIC_DEMO_MUNI_ID を設定するためこの既定は使われない。
+const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "muni_shinonsen";
 
 export async function GET(req: Request) {
   const sess = await requireAppUser();


### PR DESCRIPTION
## 概要
役場API(承認/お知らせ/月報)の `MUNI` フォールバックが UUID で、sqlite seed の `muni_shinonsen` と別自治体になっていた問題(H5)を修正。env 未設定のローカル開発で承認キュー・お知らせ・提出月報の承認が**空表示**になる原因。

## 変更(許可域のみ・共有無改修)
- `api/approvals` / `api/announcements` / `api/monthly-reports` の `NEXT_PUBLIC_DEMO_MUNI_ID ?? "<UUID>"` → `?? "muni_shinonsen"`。
- 本番(Supabase)は `NEXT_PUBLIC_DEMO_MUNI_ID` を設定するため**挙動不変**。

## 検証
- `tsc --noEmit` 通過 ✅
- E2E(別PR #81 検証時)では env 上書きで回避していた症状が、本修正で env 無しでも解消。

## 残(本PR対象外)
同フォールバックは `api/daily-logs` / `api/expenses` / `api/ai/expense-check` にも残存するが **member 側スコープ**のため別途対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)