### PR TITLE
fix(member): 活動・日報が保存できない根本原因を修正 (#82 #86)

### DIFF
--- a/src/app/api/daily-logs/route.ts
+++ b/src/app/api/daily-logs/route.ts
@@ -6,9 +6,6 @@ import { requireAppUser } from "@/lib/api/auth";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// 単一テナント(対象自治体)の ID。デモ USER とは無関係のテナント定数。
-const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
-
 type ActivityInput = {
   type: string;
   topic: string;
@@ -81,6 +78,8 @@ export async function POST(req: Request) {
 
   // 経費明細を登録
   const memberName = (await repos.users.nameOf(userId)) ?? "隊員";
+  // 承認キューのテナントは本人の所属自治体(固定定数では本番 FK 違反になる)
+  const muni = await repos.users.municipalityOf(userId);
   // ADR-012: 隊員に割り当てられたルートを優先(委託型=団体ステップ含む)。未割当は既定。
   const assigned = await repos.routes.getForUser(userId);
   for (let i = 0; i < expenses.length; i++) {
@@ -101,7 +100,7 @@ export async function POST(req: Request) {
     const { routeName, steps } =
       assigned && assigned.steps.length ? expandAssignedRoute(assigned) : expandRoute("経費", "担当課");
     await repos.approvals.enqueue({
-      muni: MUNI,
+      muni,
       kind: "経費",
       applicantId: userId,
       memberName,

--- a/src/app/member/_app.tsx
+++ b/src/app/member/_app.tsx
@@ -1482,6 +1482,7 @@ function ActivityCreateSheet({ onClose, editing, date }: { onClose: () => void; 
   const [feeling, setFeeling] = React.useState<number | null>(null);
   const [inlineExpenses, setInlineExpenses] = React.useState<InlineExpense[]>([]);
   const [saving, setSaving] = React.useState(false);
+  const [saveError, setSaveError] = React.useState<string | null>(null);
 
   function removeActivity(idx: number) {
     setActivities((cur) => cur.filter((_, i) => i !== idx));
@@ -1529,6 +1530,7 @@ function ActivityCreateSheet({ onClose, editing, date }: { onClose: () => void; 
   async function save() {
     if (!canSave) return;
     setSaving(true);
+    setSaveError(null);
     try {
       if (isEdit) {
         await updateLog(editing!.id, {
@@ -1557,7 +1559,9 @@ function ActivityCreateSheet({ onClose, editing, date }: { onClose: () => void; 
         });
         showDay(targetDate);
       }
-    } catch {
+    } catch (e) {
+      // 失敗を握り潰さず可視化(#82/#86: 押しても無反応で原因が分からない問題の対策)
+      setSaveError((e as Error)?.message || "保存に失敗しました。時間をおいて再度お試しください。");
       setSaving(false);
     }
   }
@@ -1579,6 +1583,11 @@ function ActivityCreateSheet({ onClose, editing, date }: { onClose: () => void; 
         </div>
         <div className="border-t border-slate-200 bg-white px-5 py-3">
           <div className="mx-auto max-w-2xl">
+            {saveError && (
+              <p role="alert" className="mb-2 rounded-lg bg-rose-50 px-3 py-2 text-[13px] text-rose-700">
+                保存に失敗しました: {saveError}
+              </p>
+            )}
             <button onClick={save} disabled={!canSave} className="w-full rounded-xl bg-slate-900 py-3 text-[17px] font-bold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-400">
               {saving ? "更新中…" : "更新する"}
             </button>
@@ -1733,6 +1742,11 @@ function ActivityCreateSheet({ onClose, editing, date }: { onClose: () => void; 
 
       <div className="border-t border-slate-200 bg-white px-5 py-3">
         <div className="mx-auto max-w-2xl">
+          {saveError && (
+            <p role="alert" className="mb-2 rounded-lg bg-rose-50 px-3 py-2 text-[13px] text-rose-700">
+              保存に失敗しました: {saveError}
+            </p>
+          )}
           <button onClick={save} disabled={!canSave} className="w-full rounded-xl bg-slate-900 py-3 text-[17px] font-bold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-400">
             {saving ? "記録中…" : activities.length > 0 ? `${activities.length} 件の活動を記録する` : "活動を追加してください"}
           </button>

--- a/src/lib/db/__tests__/member-save.test.ts
+++ b/src/lib/db/__tests__/member-save.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { run, get, genId } from "@/lib/db";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+
+// #82/#86 回帰防止:
+// 活動・日報の保存は固定の自治体定数ではなく「本人の所属自治体」で行われること。
+// 本番では users が想定と別テナント(テスト町)に属しており、固定定数だと
+// daily_logs.municipality_id_fkey に違反して保存が丸ごと失敗していた(DB 0 件)。
+// 別テナントのユーザーで作成し、書込先 municipality_id が本人由来であることを検証する。
+
+const OTHER_MUNI = "muni_other_test";
+const OTHER_USER = "u_other_test";
+
+describe("#82/#86 活動・日報の保存は本人の自治体に紐づく", () => {
+  beforeAll(() => {
+    // シード(新温泉町)とは別の自治体 + そこに属する隊員を投入
+    run("INSERT INTO municipalities (id,name,prefecture,annual_budget) VALUES (?,?,?,?)", [
+      OTHER_MUNI,
+      "別テスト町",
+      "兵庫県",
+      2000000,
+    ]);
+    run(
+      `INSERT INTO users (id,municipality_id,host_organization_id,organization_type,role,name,email,role_label,title,department,term,started_at,status)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+      [OTHER_USER, OTHER_MUNI, null, "member", "member", "別町 隊員", "other@member.example.jp", "移住促進", null, null, "1 年目", "2026-04-01", "active"]
+    );
+  });
+
+  it("dailyLogs.upsert は本人(別テスト町)の municipality_id で作成する", async () => {
+    const dl = await sqliteRepos.dailyLogs.upsert(OTHER_USER, "2026-07-01", { distanceKm: 12, feelingScore: 3 });
+    const row = get<{ municipality_id: string }>("SELECT municipality_id FROM daily_logs WHERE id=?", [dl.id]);
+    expect(row?.municipality_id).toBe(OTHER_MUNI);
+  });
+
+  it("activityLogs.create は本人の municipality_id で活動と日報を作成する", async () => {
+    const created = await sqliteRepos.activityLogs.create({
+      userId: OTHER_USER,
+      type: "移住相談",
+      topic: "空き家内覧",
+      hours: 2,
+      startTime: "09:00",
+      endTime: "11:00",
+      body: "内覧対応",
+      date: "2026-07-02",
+    });
+    const log = get<{ municipality_id: string; daily_log_id: string }>(
+      "SELECT municipality_id, daily_log_id FROM activity_logs WHERE id=?",
+      [created.id]
+    );
+    expect(log?.municipality_id).toBe(OTHER_MUNI);
+    // 自動結線された日報も本人の自治体であること
+    const dl = get<{ municipality_id: string }>("SELECT municipality_id FROM daily_logs WHERE id=?", [log!.daily_log_id]);
+    expect(dl?.municipality_id).toBe(OTHER_MUNI);
+  });
+
+  it("users.municipalityOf は本人の所属自治体を返す", async () => {
+    expect(await sqliteRepos.users.municipalityOf(OTHER_USER)).toBe(OTHER_MUNI);
+    // シードの隊員 m1 は新温泉町
+    expect(await sqliteRepos.users.municipalityOf("m1")).toBe("muni_shinonsen");
+  });
+});

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -33,6 +33,12 @@ import { BUDGET_CATEGORIES, DEFAULT_ALLOCATION, currentFiscalYear } from "@/lib/
 // SQLite 実装(ローカル / Vercel デモ)。SQL はここに集約し、Route からは追放する。
 const MUNI = "muni_shinonsen";
 
+// 書込時の municipality_id は固定定数ではなく本人の所属自治体から解決する。
+// (本番では users が想定と別テナントに属することがあり、固定値だと daily_logs 等で FK 違反になる)
+function muniOf(userId: string): string {
+  return get<{ municipality_id: string }>("SELECT municipality_id FROM users WHERE id=?", [userId])?.municipality_id ?? MUNI;
+}
+
 // 当月 / N ヶ月前の 'YYYY-MM' を返す(ローカル時刻基準)
 function ymOffset(offset: number): string {
   const d = new Date();
@@ -120,6 +126,9 @@ export const sqliteRepos: Repos = {
     },
     async nameOf(id) {
       return get<{ name: string }>("SELECT name FROM users WHERE id=?", [id])?.name;
+    },
+    async municipalityOf(id) {
+      return muniOf(id);
     },
     async getProfile(id) {
       const r = get<{ name: string; municipality_id: string; bio?: string; started_at?: string }>(
@@ -625,13 +634,14 @@ export const sqliteRepos: Repos = {
       const date = b.date ?? new Date().toISOString().slice(0, 10);
       const time = b.time ?? new Date().toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" });
       // ADR-021: 活動作成時に当日の daily_log を自動 upsert し daily_log_id を結線する
+      const muni = muniOf(b.userId);
       let dailyLogId = b.dailyLogId ?? null;
       if (!dailyLogId) {
         const dlId = genId("dl");
         run(
           `INSERT INTO daily_logs (id,user_id,municipality_id,log_date) VALUES (?,?,?,?)
            ON CONFLICT(user_id,log_date) DO NOTHING`,
-          [dlId, b.userId, MUNI, date]
+          [dlId, b.userId, muni, date]
         );
         const dl = get<{ id: string }>("SELECT id FROM daily_logs WHERE user_id=? AND log_date=?", [b.userId, date]);
         dailyLogId = dl?.id ?? null;
@@ -639,7 +649,7 @@ export const sqliteRepos: Repos = {
       run(
         `INSERT INTO activity_logs (id,user_id,municipality_id,daily_log_id,activity_type,topic,hours,start_time,end_time,body,log_date,log_time)
          VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
-        [id, b.userId, MUNI, dailyLogId, b.type, b.topic, b.hours, b.startTime ?? null, b.endTime ?? null, b.body, date, time]
+        [id, b.userId, muni, dailyLogId, b.type, b.topic, b.hours, b.startTime ?? null, b.endTime ?? null, b.body, date, time]
       );
       return mapLog(all("SELECT * FROM activity_logs WHERE id=?", [id])[0]);
     },
@@ -681,7 +691,7 @@ export const sqliteRepos: Repos = {
       run(
         `INSERT INTO expenses (id,user_id,municipality_id,expense_kind,category,daily_log_id,title,amount_requested,purpose,status,ai_note,citations,has_receipt,receipt_key,created_at)
          VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
-        [id, b.userId, MUNI, "single", b.category ?? "活動費", b.dailyLogId ?? null, b.title, b.amount, b.purpose, b.status ?? "申請中", "AI 判定材料は申請後に表示されます。", JSON.stringify([]), b.receiptKey ? 1 : 0, b.receiptKey ?? null, new Date().toISOString().slice(0, 10)]
+        [id, b.userId, muniOf(b.userId), "single", b.category ?? "活動費", b.dailyLogId ?? null, b.title, b.amount, b.purpose, b.status ?? "申請中", "AI 判定材料は申請後に表示されます。", JSON.stringify([]), b.receiptKey ? 1 : 0, b.receiptKey ?? null, new Date().toISOString().slice(0, 10)]
       );
       return mapExpense(all("SELECT * FROM expenses WHERE id=?", [id])[0]);
     },
@@ -693,7 +703,7 @@ export const sqliteRepos: Repos = {
             title,amount_requested,purpose,status,ai_note,citations,has_receipt,receipt_key,created_at)
          VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
         [
-          id, b.userId, MUNI, "single",
+          id, b.userId, muniOf(b.userId), "single",
           b.activityLogId, b.receiptIndex,
           b.title, b.amount, b.purpose, b.status ?? "申請中",
           "日報経由の経費(ADR-014)。AI 判定材料は申請後に表示されます。",
@@ -732,7 +742,7 @@ export const sqliteRepos: Repos = {
       run(
         `INSERT INTO monthly_reports (id,user_id,municipality_id,year_month,status,status_label,summary,plan_next)
          VALUES (?,?,?,?,?,?,?,?)`,
-        [id, b.userId, MUNI, b.ym, "submitted", "提出済", b.markdown, b.plan ?? null]
+        [id, b.userId, muniOf(b.userId), b.ym, "submitted", "提出済", b.markdown, b.plan ?? null]
       );
       return mapReport(all("SELECT * FROM monthly_reports WHERE id=?", [id])[0]);
     },
@@ -839,7 +849,7 @@ export const sqliteRepos: Repos = {
       const id = genId("dl");
       run(
         `INSERT INTO daily_logs (id,user_id,municipality_id,log_date,note,distance_km,expense_amount,feeling_score) VALUES (?,?,?,?,?,?,?,?)`,
-        [id, userId, MUNI, date, fields?.note ?? null, fields?.distanceKm ?? null, fields?.expenseAmount ?? null, fields?.feelingScore ?? null]
+        [id, userId, muniOf(userId), date, fields?.note ?? null, fields?.distanceKm ?? null, fields?.expenseAmount ?? null, fields?.feelingScore ?? null]
       );
       return mapDailyLog(all("SELECT * FROM daily_logs WHERE id=?", [id])[0]);
     },
@@ -901,7 +911,7 @@ export const sqliteRepos: Repos = {
         `INSERT INTO monthly_cycles (id,user_id,municipality_id,year_month,monthly_goal,action_plan,intake,reflection,status)
          VALUES (?,?,?,?,?,?,?,?,?)`,
         [
-          id, userId, MUNI, ym,
+          id, userId, muniOf(userId), ym,
           fields.monthlyGoal ?? null,
           JSON.stringify(fields.actionPlan ?? []),
           fields.intake ? JSON.stringify(fields.intake) : null,

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -149,6 +149,13 @@ function supabase() {
   );
 }
 
+// 書込時の municipality_id は固定定数ではなく本人の所属自治体から解決する。
+// (本番の users は MUNI 定数と別テナント=テスト町 に属しており、固定値だと daily_logs 等で FK 違反になる)
+async function muniOf(userId: string): Promise<string> {
+  const { data } = await supabase().from("users").select("municipality_id").eq("id", userId).maybeSingle();
+  return (data?.municipality_id as string) ?? MUNI;
+}
+
 // Supabase の occurred_at(timestamptz)→ log_date / log_time に変換してマッパーに渡す
 function toLogRow(r: Record<string, unknown>): Record<string, unknown> {
   const oa = r.occurred_at as string | null;
@@ -175,6 +182,9 @@ export const supabaseRepos: Repos = {
     async nameOf(id) {
       const { data } = await supabase().from("users").select("name").eq("id", id).single();
       return data?.name;
+    },
+    async municipalityOf(id) {
+      return muniOf(id);
     },
     async getProfile(id) {
       const { data } = await supabase()
@@ -836,7 +846,7 @@ export const supabaseRepos: Repos = {
         .from("activity_logs")
         .insert({
           user_id: b.userId,
-          municipality_id: MUNI,
+          municipality_id: await muniOf(b.userId),
           daily_log_id: dailyLogId,
           activity_type: b.type,
           topic: b.topic,
@@ -931,7 +941,7 @@ export const supabaseRepos: Repos = {
         .from("daily_logs")
         .insert({
           user_id: userId,
-          municipality_id: MUNI,
+          municipality_id: await muniOf(userId),
           log_date: date,
           note: fields?.note ?? null,
           distance_km: fields?.distanceKm ?? null,
@@ -967,7 +977,7 @@ export const supabaseRepos: Repos = {
         .from("expenses")
         .insert({
           user_id: b.userId,
-          municipality_id: MUNI,
+          municipality_id: await muniOf(b.userId),
           expense_kind: "single",
           category: b.category ?? "活動費",
           daily_log_id: b.dailyLogId ?? null,
@@ -989,7 +999,7 @@ export const supabaseRepos: Repos = {
         .from("expenses")
         .insert({
           user_id: b.userId,
-          municipality_id: MUNI,
+          municipality_id: await muniOf(b.userId),
           expense_kind: "single",
           source_activity_log_id: b.activityLogId,
           source_receipt_index: b.receiptIndex,
@@ -1047,7 +1057,7 @@ export const supabaseRepos: Repos = {
       }
       const { data } = await supabase()
         .from("monthly_reports")
-        .insert({ user_id: b.userId, municipality_id: MUNI, year_month: b.ym, status: "submitted", status_label: "提出済", summary: b.markdown, plan_next: b.plan ?? null })
+        .insert({ user_id: b.userId, municipality_id: await muniOf(b.userId), year_month: b.ym, status: "submitted", status_label: "提出済", summary: b.markdown, plan_next: b.plan ?? null })
         .select()
         .single();
       return mapReport(data!);
@@ -1207,7 +1217,7 @@ export const supabaseRepos: Repos = {
     async log(c) {
       await supabase().from("consultations").insert({
         user_id: c.userId,
-        municipality_id: MUNI,
+        municipality_id: await muniOf(c.userId),
         context_kind: c.contextKind,
         input_text: c.input,
         output_text: c.output,
@@ -1268,7 +1278,7 @@ export const supabaseRepos: Repos = {
       }
       const { data } = await supabase()
         .from("monthly_cycles")
-        .insert({ user_id: userId, municipality_id: MUNI, year_month: ym, ...patch })
+        .insert({ user_id: userId, municipality_id: await muniOf(userId), year_month: ym, ...patch })
         .select()
         .single();
       return mapMonthlyCycle(toCycleRow(data!));

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -162,6 +162,8 @@ export interface Repos {
   users: {
     count(): Promise<number>;
     nameOf(id: string): Promise<string | undefined>;
+    /** 書込時に使うテナント = 本人の所属自治体。固定定数では本番のテナント不一致で FK 違反になるため、必ず本人由来で解決する。 */
+    municipalityOf(id: string): Promise<string>;
     getProfile(id: string): Promise<{ name: string; municipality: string; bio?: string; assigned_at?: string } | null>;
   };
   super: {


### PR DESCRIPTION
## 概要
本番で member の活動・日報が**1件も保存できていなかった**(`activity_logs`/`daily_logs`/`expenses` が全て 0 件)致命バグの根本原因修正。Issue #82 / #86。

## 根本原因(本番ログで確定)
Postgres ログに `insert or update on table "daily_logs" violates foreign key constraint "daily_logs_municipality_id_fkey"` が記録。
- コードの固定テナント定数 `MUNI = 10000000…(新温泉町)` が、**本番の実テナント `99000000…(テスト町)`** と不一致。
- 本番の全 users / host_organizations / approval_routes は `99000000` に所属。`10000000` は存在しない → 書込が毎回 FK 違反 → POST 500 → クライアントの `save()` が握り潰し → **画面上は「押しても無反応」**。

## 修正
- **repositories(sqlite/supabase)**: 書込時の `municipality_id` を固定定数ではなく**本人の所属自治体**(`users.municipality_id`)から解決。`users.municipalityOf()` を追加。対象は本人由来の書込パス: `daily_logs` / `activity_logs` / `expenses` / `monthly_reports` / `monthly_cycles` / `consultations`。
- **api/daily-logs**: 承認キューのテナントも本人の自治体に。
- **member/_app.tsx**: `save()` の `catch` でエラーを握り潰さず画面に可視化(#82/#86 の「無反応」UX 対策)。
- **test**: 別テナントのユーザーで作成し `municipality_id` が本人由来になることを検証する回帰テストを追加。

## 検証
- `npm test` 緑(回帰テスト3件含む)/ `tsc --noEmit` 緑 / `npm run build` 緑。
- 本番反映には本 PR のデプロイが必要(現行デプロイは未修正のまま保存不可)。

## 注意 / 別件
- 共有ファイル(`repositories/*`, `types.ts`)への変更を含みます(member ルール: 事前報告対象)。
- **別バグを発見**: 本番 `expenses` は `receipt_path` のみで `receipt_key` 列が無く、経費作成パスは別途修正が必要(本 PR 範囲外。別 Issue 化を推奨)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)