### PR TITLE
fix(manager): 差戻しを対象(月報・経費)の status に反映(承認連動の穴)

### DIFF
--- a/src/app/api/approvals/[id]/decide/__tests__/reject-reflect.test.ts
+++ b/src/app/api/approvals/[id]/decide/__tests__/reject-reflect.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+
+// 差戻し(reject)が対象(月報・経費)の status に反映されることの回帰テスト(承認連動の穴)。
+// これが無いと、承認キューから外れても月報は「提出済」、経費は元状態のまま残る。
+
+const MUNI = "muni_shinonsen";
+
+async function decideReject(id: string, comment: string) {
+  vi.resetModules();
+  vi.stubEnv("AUTH_PROVIDER", "none");
+  vi.stubEnv("DEV_USER_ROLE", "manager");
+  vi.stubEnv("DEV_USER_ID", "s1");
+  const mod = await import("../route");
+  const req = new Request("http://test/api/approvals/x/decide", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ action: "reject", comment }),
+  });
+  const res = await mod.POST(req, { params: Promise.resolve({ id }) });
+  return { status: res.status, json: await res.json() };
+}
+
+// 単段の pending 承認を作り、その id を取得する(enqueue は void のため title で引く)。
+async function enqueueSingleStep(kind: string, title: string, targetTable: string, targetId: string) {
+  await sqliteRepos.approvals.enqueue({
+    muni: MUNI,
+    kind,
+    applicantId: "m1",
+    memberName: "テスト隊員",
+    title,
+    ai: "",
+    detail: {},
+    routeName: "担当課",
+    steps: [{ approverType: "dept", approverLabel: "担当課", status: "pending" }],
+    targetTable,
+    targetId,
+  });
+  const pending = await sqliteRepos.approvals.listPending(MUNI);
+  const found = pending.find((a) => a.title === title);
+  if (!found) throw new Error("enqueue した承認が見つからない");
+  return found.id;
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("差戻しの対象反映(承認連動)", () => {
+  it("月報の差戻しで monthly_reports が rejected になる", async () => {
+    const rep = await sqliteRepos.monthlyReports.submit({ userId: "m2", ym: "2026-04", markdown: "テスト月報本文" });
+    expect(rep.status).toBe("submitted");
+
+    const apId = await enqueueSingleStep("月次報告", "差戻しテスト月報", "monthly_reports", rep.id);
+    const r = await decideReject(apId, "活動時間の内訳を追記してください");
+    expect(r.status).toBe(200);
+    expect(r.json.result).toBe("rejected");
+
+    const after = (await sqliteRepos.monthlyReports.listByUser("m2")).find((x) => x.id === rep.id);
+    expect(after?.status).toBe("rejected");
+    expect(after?.statusLabel).toContain("差戻し");
+  });
+
+  it("経費の差戻しで expenses が「差戻し」になる", async () => {
+    // 既存シード経費 e2(未精算)を対象にする。
+    const before = (await sqliteRepos.expenses.listByUser("m1")).find((x) => x.id === "e2");
+    expect(before?.status).not.toBe("差戻し");
+
+    const apId = await enqueueSingleStep("経費", "差戻しテスト経費", "expenses", "e2");
+    const r = await decideReject(apId, "領収書の添付をお願いします");
+    expect(r.status).toBe(200);
+    expect(r.json.result).toBe("rejected");
+
+    const after = (await sqliteRepos.expenses.listByUser("m1")).find((x) => x.id === "e2");
+    expect(after?.status).toBe("差戻し");
+  });
+});

--- a/src/app/api/approvals/[id]/decide/route.ts
+++ b/src/app/api/approvals/[id]/decide/route.ts
@@ -42,6 +42,13 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
     if (row.kind === "経費") await repos.expenses.update(row.target_id, { status: "承認" });
   }
 
+  // 差戻しの反映:対象を差戻し状態に戻し、隊員が修正・再提出できるようにする。
+  // これが無いと、承認キューから外れても月報/経費は提出済・承認のまま残る(承認連動の穴)。
+  if (next.status === "rejected" && row.target_id) {
+    if (row.kind === "月次報告") await repos.monthlyReports.markRejected(row.target_id);
+    if (row.kind === "経費") await repos.expenses.update(row.target_id, { status: "差戻し" });
+  }
+
   const updated = await repos.approvals.getById(id);
   return ok({ approval: updated, result: next.status });
 }

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -739,6 +739,9 @@ export const sqliteRepos: Repos = {
     async markApproved(id) {
       run("UPDATE monthly_reports SET status='approved', status_label='役場承認' WHERE id=?", [id]);
     },
+    async markRejected(id) {
+      run("UPDATE monthly_reports SET status='rejected', status_label='差戻し（要修正）' WHERE id=?", [id]);
+    },
     async revertToSubmitted(userId, ym) {
       run(
         "UPDATE monthly_reports SET status='submitted', status_label='提出済(再確認待ち)' WHERE user_id=? AND year_month=? AND status='approved'",

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -1058,6 +1058,12 @@ export const supabaseRepos: Repos = {
         .update({ status: "approved", status_label: "役場承認" })
         .eq("id", id);
     },
+    async markRejected(id) {
+      await supabase()
+        .from("monthly_reports")
+        .update({ status: "rejected", status_label: "差戻し（要修正）" })
+        .eq("id", id);
+    },
     async revertToSubmitted(userId, ym) {
       await supabase()
         .from("monthly_reports")

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -276,6 +276,8 @@ export interface Repos {
     /** 隊員が月報を役場に提出(同月の下書きがあれば更新、なければ作成)。status=submitted */
     submit(b: { userId: string; ym: string; markdown: string; plan?: string }): Promise<ReportDTO>;
     markApproved(id: string): Promise<void>;
+    /** 役場が月報を差戻し → status=rejected(隊員が修正・再提出できる状態に戻す) */
+    markRejected(id: string): Promise<void>;
     /** 活動報告を編集/削除した場合、同月の承認済み月報を「提出済」に差し戻す */
     revertToSubmitted(userId: string, ym: string): Promise<void>;
   };


### PR DESCRIPTION
## 概要
承認 decide ルートが**最終承認時のみ**対象を更新し、**差戻し(rejected)時は何も反映していなかった**問題を修正。差戻しても月報は「提出済」・経費は元状態のまま残り、隊員に再提出すべき状態が伝わらなかった(承認連動の穴)。

## 変更
### 許可域(api/approvals)
- `decide` ルートに `next.status==="rejected"` 反映ブロックを追加:
  - 月次報告 → `monthlyReports.markRejected`
  - 経費 → `expenses.update(status:"差戻し")`（既存メソッド流用）

### 共有(追加のみ・事前報告済 / 既存メソッド無改変)
- `monthlyReports.markRejected(id)` を `types.ts` / `sqlite.ts` / `supabase.ts` に追加。
  `status='rejected'`, `status_label='差戻し（要修正）'`（manager グリッドは未知 status を draft に丸めるため安全に下書き表示）。

### テスト(許可域)
- 月報・経費それぞれの差戻し反映を vitest で検証。

## 検証
- `npm test` → 21 passed ✅（新規 reject-reflect 2 件含む）
- `tsc --noEmit` 通過 ✅

## 補足
差戻しの重複承認防止（再提出時の二重キュー化）は別トピックとして残置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)