### PR TITLE
fix(manager): 月報の再提出で承認キューが二重化しないようにする

### DIFF
--- a/src/app/api/monthly-reports/__tests__/dedup-resubmit.test.ts
+++ b/src/app/api/monthly-reports/__tests__/dedup-resubmit.test.ts
@@ -5,7 +5,8 @@ import { sqliteRepos } from "@/lib/db/repositories/sqlite";
 // submit() は同月を上書きするため、2 回目の提出で新たな pending 承認を作ってはいけない。
 
 // route の MUNI フォールバック(env 未設定時)と同じ値で承認キューを照合する。
-const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
+// #95 でルート既定が "muni_shinonsen" に整合済み。ここもそれに合わせる(ズレるとキュー照合が空振りする)。
+const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "muni_shinonsen";
 
 async function submit(ym: string, markdown: string) {
   vi.resetModules();

--- a/src/app/api/monthly-reports/__tests__/dedup-resubmit.test.ts
+++ b/src/app/api/monthly-reports/__tests__/dedup-resubmit.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+
+// 月報の再提出で承認キューが二重にならないことの回帰テスト。
+// submit() は同月を上書きするため、2 回目の提出で新たな pending 承認を作ってはいけない。
+
+// route の MUNI フォールバック(env 未設定時)と同じ値で承認キューを照合する。
+const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
+
+async function submit(ym: string, markdown: string) {
+  vi.resetModules();
+  vi.stubEnv("AUTH_PROVIDER", "none");
+  vi.stubEnv("DEV_USER_ROLE", "member");
+  vi.stubEnv("DEV_USER_ID", "m2"); // m2 はシードに月報・月報承認が無く、独立して検証できる
+  const mod = await import("../route");
+  const req = new Request("http://test/api/monthly-reports", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ym, markdown }),
+  });
+  const res = await mod.POST(req);
+  return { status: res.status, json: await res.json() };
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("月報 再提出の二重キュー防止", () => {
+  it("同月を 2 回提出しても承認キューは 1 件のまま", async () => {
+    const first = await submit("2026-04", "初回提出の本文");
+    expect(first.status).toBe(201);
+
+    const pendingAfter1 = (await sqliteRepos.approvals.listPending(MUNI)).filter(
+      (a) => a.kind === "月次報告" && a.applicantId === "m2"
+    );
+    expect(pendingAfter1.length).toBe(1);
+
+    // 内容を直して再提出
+    const second = await submit("2026-04", "修正後の本文(再提出)");
+    expect(second.status).toBe(201);
+
+    const pendingAfter2 = (await sqliteRepos.approvals.listPending(MUNI)).filter(
+      (a) => a.kind === "月次報告" && a.applicantId === "m2"
+    );
+    expect(pendingAfter2.length).toBe(1); // 二重化しない
+  });
+
+  it("別の月は別の承認キューになる", async () => {
+    await submit("2026-04", "4 月分");
+    await submit("2026-05", "5 月分");
+    const pending = (await sqliteRepos.approvals.listPending(MUNI)).filter(
+      (a) => a.kind === "月次報告" && a.applicantId === "m2"
+    );
+    expect(pending.length).toBe(2);
+  });
+});

--- a/src/app/api/monthly-reports/route.ts
+++ b/src/app/api/monthly-reports/route.ts
@@ -36,22 +36,31 @@ export async function POST(req: Request) {
   const userId = sess.userId;
   const report = await repos.monthlyReports.submit({ userId, ym: b.ym, markdown: b.markdown.trim(), plan: b.plan?.trim() });
 
+  // 再提出時の二重キュー防止: 同一隊員・同月の月次報告が既に承認待ちなら再エンキューしない。
+  // submit() は同月を上書きするため report.id は不変。役場は既存の承認1件で再提出後の内容も確認できる。
+  const title = `${report.yearMonth} の月次報告`;
+  const alreadyQueued = (await repos.approvals.listPending(MUNI)).some(
+    (a) => a.kind === "月次報告" && a.applicantId === userId && a.title === title
+  );
+
   // 役場側の承認キューに投入(月次報告 ルート)
-  const memberName = (await repos.users.nameOf(userId)) ?? "隊員";
-  const { routeName, steps } = expandRoute("月次報告", "担当課");
-  await repos.approvals.enqueue({
-    muni: MUNI,
-    kind: "月次報告",
-    applicantId: userId,
-    memberName,
-    title: `${report.yearMonth} の月次報告`,
-    ai: "隊員が提出した月次報告。活動ログから AI 生成・本人確認済み。",
-    detail: { kind: "月次報告", ym: b.ym, body: b.markdown.trim(), plan: b.plan?.trim() ?? "" },
-    routeName,
-    steps,
-    targetTable: "monthly_reports",
-    targetId: report.id,
-  });
+  if (!alreadyQueued) {
+    const memberName = (await repos.users.nameOf(userId)) ?? "隊員";
+    const { routeName, steps } = expandRoute("月次報告", "担当課");
+    await repos.approvals.enqueue({
+      muni: MUNI,
+      kind: "月次報告",
+      applicantId: userId,
+      memberName,
+      title,
+      ai: "隊員が提出した月次報告。活動ログから AI 生成・本人確認済み。",
+      detail: { kind: "月次報告", ym: b.ym, body: b.markdown.trim(), plan: b.plan?.trim() ?? "" },
+      routeName,
+      steps,
+      targetTable: "monthly_reports",
+      targetId: report.id,
+    });
+  }
 
   return ok(report, 201);
 }


### PR DESCRIPTION
## 概要
`monthly-reports` POST が提出のたびに無条件で `enqueue` しており、隊員が同月の月報を**修正・再提出**すると承認キューに同じ月報が**二重に積まれる**問題を修正。`submit()` は同月を上書きするため月報は1件なのに、承認だけ重複していた。

## 変更(許可域のみ・共有/既存メソッド無改変)
- enqueue 前に `listPending` で「同一隊員・同月の月次報告が承認待ちか」を判定し、既にあれば**再エンキューしない**（既存の承認1件を使い回す）。
- `api/monthly-reports` のみ。`listPending` は既存メソッドを流用。

## 検証
- `npm test` → 21 passed ✅（新規 dedup 2 件：同月2回提出で承認1件 / 別月は別承認）
- `tsc --noEmit` 通過 ✅

## 補足
- 既存 pending 承認の `detail` は初回提出時のスナップショット。再提出後の最新内容は対象月報(`target_id`)側に反映済みで、役場はそちらで確認可能。承認カードの detail 更新までは本PR対象外（必要なら別途 `approvals` 更新メソッド追加で対応）。
- `MUNI` フォールバック整合(#95)とはファイル別領域のため独立してマージ可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)