### PR TITLE
feat(super): 管理画面の編集・削除導線とアカウント自治体統合(#119/#113ほか)

### DIFF
--- a/src/app/api/super/municipalities/[id]/route.ts
+++ b/src/app/api/super/municipalities/[id]/route.ts
@@ -38,10 +38,12 @@ export async function DELETE(_req: Request, { params }: { params: Promise<{ id: 
   const { id } = await params;
   const detail = await getRepos().super.municipalityDetail(id);
   if (!detail) return bad("自治体が見つかりません", 404);
-  const userCount = detail.members.length + detail.staff.length;
-  if (userCount > 0) {
-    return bad(`所属ユーザーが ${userCount} 名います。先にユーザーを移動/削除してください`, 409);
+  // 在籍チェックは role を問わず全ユーザーを数える(super 等が municipality_id を持つ場合の取り残し防止)
+  const belonging = await getRepos().super.listUsers({ municipalityId: id });
+  if (belonging.length > 0) {
+    return bad(`所属ユーザーが ${belonging.length} 名います。先にユーザーを移動/削除してください`, 409);
   }
   await getRepos().super.deleteMunicipality(id);
-  return ok(null, 204);
+  // 204(null body)は NextResponse.json / クライアントの res.json() 双方で例外になるため 200+body を返す
+  return ok({ ok: true });
 }

--- a/src/app/api/super/municipalities/[id]/route.ts
+++ b/src/app/api/super/municipalities/[id]/route.ts
@@ -1,4 +1,4 @@
-import { ok, bad } from "@/lib/api/http";
+import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
 import { requireSuper } from "@/lib/api/auth";
 
@@ -13,4 +13,35 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
   const detail = await getRepos().super.municipalityDetail(id);
   if (!detail) return bad("自治体が見つかりません", 404);
   return ok(detail);
+}
+
+/** PATCH /api/super/municipalities/[id] — 自治体の名称/都道府県/年間予算を更新(super 専用) */
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const sess = await requireSuper();
+  if (sess instanceof Response) return sess;
+  const { id } = await params;
+  const body = await readJson<{ name?: string; prefecture?: string; annualBudget?: number }>(req);
+  const patch: { name?: string; prefecture?: string; annualBudget?: number } = {};
+  if (typeof body.name === "string" && body.name.trim()) patch.name = body.name.trim();
+  if (typeof body.prefecture === "string" && body.prefecture.trim()) patch.prefecture = body.prefecture.trim();
+  if (typeof body.annualBudget === "number" && body.annualBudget >= 0) patch.annualBudget = body.annualBudget;
+  if (Object.keys(patch).length === 0) return bad("更新する項目がありません", 400);
+  const updated = await getRepos().super.updateMunicipality(id, patch);
+  if (!updated) return bad("自治体が見つかりません", 404);
+  return ok(updated);
+}
+
+/** DELETE /api/super/municipalities/[id] — 自治体を削除(super 専用)。所属ユーザーが居る場合は拒否 */
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const sess = await requireSuper();
+  if (sess instanceof Response) return sess;
+  const { id } = await params;
+  const detail = await getRepos().super.municipalityDetail(id);
+  if (!detail) return bad("自治体が見つかりません", 404);
+  const userCount = detail.members.length + detail.staff.length;
+  if (userCount > 0) {
+    return bad(`所属ユーザーが ${userCount} 名います。先にユーザーを移動/削除してください`, 409);
+  }
+  await getRepos().super.deleteMunicipality(id);
+  return ok(null, 204);
 }

--- a/src/app/api/super/users/[id]/route.ts
+++ b/src/app/api/super/users/[id]/route.ts
@@ -44,5 +44,6 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ id: s
   }
 
   await getRepos().super.deleteUser(id);
-  return ok(null, 204);
+  // 204(null body)は NextResponse.json / クライアントの res.json() 双方で例外になるため 200+body を返す
+  return ok({ ok: true });
 }

--- a/src/app/super/_app.tsx
+++ b/src/app/super/_app.tsx
@@ -673,12 +673,14 @@ function MuniEditModal({
 
   async function submit() {
     if (!name.trim() || !prefecture.trim()) { setErr("自治体名・都道府県は必須です"); return; }
+    const budgetNum = Number(budget);
+    if (!Number.isFinite(budgetNum) || budgetNum < 0) { setErr("年間活動費枠は0以上の数値で入力してください"); return; }
     setBusy(true); setErr("");
     try {
       await apiPatch(`/api/super/municipalities/${muni.id}`, {
         name: name.trim(),
         prefecture: prefecture.trim(),
-        annualBudget: Number(budget) || 0,
+        annualBudget: budgetNum,
       });
       onSaved();
     } catch (e) { setErr((e as Error).message); setBusy(false); }

--- a/src/app/super/_app.tsx
+++ b/src/app/super/_app.tsx
@@ -22,7 +22,6 @@ import {
 } from "lucide-react";
 import type {
   SuperMuniDetail,
-  SuperUserRow,
   SuperAnalytics,
 } from "@/lib/db/repositories/types";
 
@@ -48,7 +47,11 @@ type Overview = {
   totals: { municipalities: number; members: number; managers: number; admins: number; supers: number };
 };
 
-type Tab = "overview" | "accounts" | "analytics";
+type Tab = "overview" | "analytics";
+
+// #119: 自治体詳細でのアカウント編集に使う選択肢
+const STATUS_OPTS = ["active", "retired", "suspended"];
+const STAFF_ROLE_OPTS = ["manager", "admin"];
 
 export function SuperApp() {
   const [data, setData] = React.useState<Overview | null>(null);
@@ -107,7 +110,6 @@ export function SuperApp() {
         <div className="mx-auto flex max-w-5xl gap-1">
           {([
             ["overview", "概要"],
-            ["accounts", "アカウント"],
             ["analytics", "分析"],
           ] as [Tab, string][]).map(([key, label]) => (
             <button
@@ -143,7 +145,6 @@ export function SuperApp() {
             onOpenDetail={openDetail}
           />
         )}
-        {data && tab === "accounts" && <AccountsTab municipalities={data.municipalities} />}
         {data && tab === "analytics" && <AnalyticsTab />}
       </div>
 
@@ -151,7 +152,12 @@ export function SuperApp() {
       {muniModal && (
         <MuniModal
           onClose={() => setMuniModal(false)}
-          onCreated={() => { setMuniModal(false); loadOverview(); }}
+          onCreated={(created) => {
+            // #113: 作成後そのまま「管理者を招待」へ続けて誘導
+            setMuniModal(false);
+            loadOverview();
+            setInviteFor(created);
+          }}
         />
       )}
       {/* #65 管理者招待モーダル */}
@@ -291,6 +297,29 @@ function DetailSheet({
     }
   }
 
+  // #119: 自治体ごとのアカウント管理(role/status 変更・削除)を詳細内で行う
+  async function patchUser(id: string, body: { role?: string; status?: string }) {
+    setOpErr(null);
+    try {
+      await apiPatch(`/api/super/users/${id}`, body);
+      onReload();
+    } catch (e) {
+      setOpErr(e instanceof Error ? e.message : "更新に失敗しました");
+    }
+  }
+
+  async function removeUser(id: string, name: string) {
+    if (!window.confirm(`「${name}」を削除します。元に戻せません。よろしいですか?`)) return;
+    setOpErr(null);
+    try {
+      await apiDelete(`/api/super/users/${id}`);
+      onReload();
+    } catch (e) {
+      // 自分自身の削除はサーバ側で 400 ブロック。
+      setOpErr(e instanceof Error ? e.message : "削除に失敗しました");
+    }
+  }
+
   return (
     <div className="fixed inset-0 z-40 flex justify-end">
       <div className="absolute inset-0 bg-slate-900/30" onClick={onClose} />
@@ -362,6 +391,7 @@ function DetailSheet({
                     <th className="px-3 py-2 text-left">任期</th>
                     <th className="px-3 py-2 text-left">着任日</th>
                     <th className="px-3 py-2 text-left">状態</th>
+                    <th className="px-3 py-2 text-right">操作</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-slate-100">
@@ -372,12 +402,27 @@ function DetailSheet({
                       <td className="px-3 py-2 text-slate-500">{m.term}</td>
                       <td className="px-3 py-2 text-slate-500">{m.startedAt}</td>
                       <td className="px-3 py-2">
-                        <StatusBadge status={m.status} />
+                        <select
+                          value={m.status}
+                          onChange={(e) => patchUser(m.id, { status: e.target.value })}
+                          className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-[12px]"
+                        >
+                          {STATUS_OPTS.map((s) => <option key={s} value={s}>{s}</option>)}
+                        </select>
+                      </td>
+                      <td className="px-3 py-2 text-right">
+                        <button
+                          onClick={() => removeUser(m.id, m.name)}
+                          title="この隊員を削除"
+                          className="inline-flex items-center gap-1 rounded-md border border-red-200 px-2 py-1 text-[11px] font-semibold text-red-600 hover:bg-red-50"
+                        >
+                          <Trash2 className="h-3 w-3" /> 削除
+                        </button>
                       </td>
                     </tr>
                   ))}
                   {detail.members.length === 0 && (
-                    <tr><td colSpan={5} className="px-3 py-6 text-center text-slate-400">隊員がいません</td></tr>
+                    <tr><td colSpan={6} className="px-3 py-6 text-center text-slate-400">隊員がいません</td></tr>
                   )}
                 </tbody>
               </table>
@@ -393,6 +438,7 @@ function DetailSheet({
                     <th className="px-3 py-2 text-left">役職</th>
                     <th className="px-3 py-2 text-left">所属課</th>
                     <th className="px-3 py-2 text-left">role</th>
+                    <th className="px-3 py-2 text-right">操作</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-slate-100">
@@ -401,11 +447,28 @@ function DetailSheet({
                       <td className="px-3 py-2 font-medium">{s.name}</td>
                       <td className="px-3 py-2 text-slate-500">{s.title}</td>
                       <td className="px-3 py-2 text-slate-500">{s.dept}</td>
-                      <td className="px-3 py-2 text-slate-500">{s.role}</td>
+                      <td className="px-3 py-2">
+                        <select
+                          value={s.role}
+                          onChange={(e) => patchUser(s.id, { role: e.target.value })}
+                          className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-[12px]"
+                        >
+                          {STAFF_ROLE_OPTS.map((r) => <option key={r} value={r}>{r}</option>)}
+                        </select>
+                      </td>
+                      <td className="px-3 py-2 text-right">
+                        <button
+                          onClick={() => removeUser(s.id, s.name)}
+                          title="この職員を削除"
+                          className="inline-flex items-center gap-1 rounded-md border border-red-200 px-2 py-1 text-[11px] font-semibold text-red-600 hover:bg-red-50"
+                        >
+                          <Trash2 className="h-3 w-3" /> 削除
+                        </button>
+                      </td>
                     </tr>
                   ))}
                   {detail.staff.length === 0 && (
-                    <tr><td colSpan={4} className="px-3 py-6 text-center text-slate-400">職員がいません</td></tr>
+                    <tr><td colSpan={5} className="px-3 py-6 text-center text-slate-400">職員がいません</td></tr>
                   )}
                 </tbody>
               </table>
@@ -442,145 +505,6 @@ function DetailSheet({
         )}
       </div>
     </div>
-  );
-}
-
-/* ---------------- アカウント管理タブ(#66) ---------------- */
-
-const ROLE_OPTS = ["member", "manager", "admin", "super"];
-const STATUS_OPTS = ["active", "retired", "suspended"];
-
-function AccountsTab({ municipalities }: { municipalities: MuniRow[] }) {
-  const [users, setUsers] = React.useState<SuperUserRow[] | null>(null);
-  const [fMuni, setFMuni] = React.useState("");
-  const [fRole, setFRole] = React.useState("");
-  const [fStatus, setFStatus] = React.useState("");
-  const [err, setErr] = React.useState<string | null>(null);
-
-  const load = React.useCallback(() => {
-    const qs = new URLSearchParams();
-    if (fMuni) qs.set("municipalityId", fMuni);
-    if (fRole) qs.set("role", fRole);
-    if (fStatus) qs.set("status", fStatus);
-    const q = qs.toString();
-    apiGet<SuperUserRow[]>(`/api/super/users${q ? `?${q}` : ""}`)
-      .then(setUsers)
-      .catch(() => setErr("ユーザーの取得に失敗しました"));
-  }, [fMuni, fRole, fStatus]);
-
-  React.useEffect(() => {
-    load();
-  }, [load]);
-
-  async function patch(id: string, body: { role?: string; status?: string; municipalityId?: string }) {
-    try {
-      const updated = await apiPatch<SuperUserRow>(`/api/super/users/${id}`, body);
-      setUsers((prev) => (prev ? prev.map((u) => (u.id === id ? updated : u)) : prev));
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : "更新に失敗しました");
-      load(); // 失敗時(自己変更ブロック等)はサーバ状態に戻す
-    }
-  }
-
-  async function remove(u: SuperUserRow) {
-    if (!window.confirm(`「${u.name}」(${u.email})を削除します。元に戻せません。よろしいですか?`)) return;
-    try {
-      await apiDelete(`/api/super/users/${u.id}`);
-      setUsers((prev) => (prev ? prev.filter((x) => x.id !== u.id) : prev));
-    } catch (e) {
-      // 自分自身の削除はサーバ側で 400 ブロック。メッセージを表示。
-      setErr(e instanceof Error ? e.message : "削除に失敗しました");
-    }
-  }
-
-  return (
-    <>
-      <div className="mb-4 flex flex-wrap gap-2">
-        <Select value={fMuni} onChange={setFMuni} label="全自治体">
-          {municipalities.map((m) => (
-            <option key={m.id} value={m.id}>{m.name}</option>
-          ))}
-        </Select>
-        <Select value={fRole} onChange={setFRole} label="全ロール">
-          {ROLE_OPTS.map((r) => <option key={r} value={r}>{r}</option>)}
-        </Select>
-        <Select value={fStatus} onChange={setFStatus} label="全状態">
-          {STATUS_OPTS.map((s) => <option key={s} value={s}>{s}</option>)}
-        </Select>
-      </div>
-
-      {err && <div className="mb-3 rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-[12px] text-red-700">{err}</div>}
-
-      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
-        <table className="w-full text-[13px]">
-          <thead className="bg-slate-50 text-[11px] uppercase text-slate-500">
-            <tr>
-              <th className="px-3 py-2.5 text-left">氏名</th>
-              <th className="px-3 py-2.5 text-left">メール</th>
-              <th className="px-3 py-2.5 text-left">自治体</th>
-              <th className="px-3 py-2.5 text-left">role</th>
-              <th className="px-3 py-2.5 text-left">status</th>
-              <th className="px-3 py-2.5 text-right">活動記録</th>
-              <th className="px-3 py-2.5 text-right">操作</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-slate-100">
-            {(users ?? []).map((u) => (
-              <tr key={u.id} className="hover:bg-slate-50">
-                <td className="px-3 py-2 font-medium">{u.name}</td>
-                <td className="px-3 py-2 text-slate-500">{u.email}</td>
-                <td className="px-3 py-2">
-                  <select
-                    value={u.municipalityId ?? ""}
-                    onChange={(e) => patch(u.id, { municipalityId: e.target.value })}
-                    className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-[12px] disabled:opacity-50"
-                  >
-                    <option value="">(未所属)</option>
-                    {municipalities.map((m) => (
-                      <option key={m.id} value={m.id}>{m.name}</option>
-                    ))}
-                  </select>
-                </td>
-                <td className="px-3 py-2">
-                  <select
-                    value={u.role}
-                    onChange={(e) => patch(u.id, { role: e.target.value })}
-                    className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-[12px] disabled:opacity-50"
-                  >
-                    {ROLE_OPTS.map((r) => <option key={r} value={r}>{r}</option>)}
-                  </select>
-                </td>
-                <td className="px-3 py-2">
-                  <select
-                    value={u.status}
-                    onChange={(e) => patch(u.id, { status: e.target.value })}
-                    className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-[12px] disabled:opacity-50"
-                  >
-                    {STATUS_OPTS.map((s) => <option key={s} value={s}>{s}</option>)}
-                  </select>
-                </td>
-                <td className="px-3 py-2 text-right tabular-nums">{u.activityLogs}</td>
-                <td className="px-3 py-2 text-right">
-                  <button
-                    onClick={() => remove(u)}
-                    title="このユーザーを削除"
-                    className="inline-flex items-center gap-1 rounded-md border border-red-200 px-2 py-1 text-[11px] font-semibold text-red-600 hover:bg-red-50"
-                  >
-                    <Trash2 className="h-3 w-3" /> 削除
-                  </button>
-                </td>
-              </tr>
-            ))}
-            {users && users.length === 0 && (
-              <tr><td colSpan={7} className="px-3 py-8 text-center text-slate-400">該当ユーザーがいません</td></tr>
-            )}
-            {!users && !err && (
-              <tr><td colSpan={7} className="px-3 py-8 text-center text-slate-400">読み込み中…</td></tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-    </>
   );
 }
 
@@ -698,7 +622,7 @@ function Modal({ title, onClose, children }: { title: string; onClose: () => voi
   );
 }
 
-function MuniModal({ onClose, onCreated }: { onClose: () => void; onCreated: () => void }) {
+function MuniModal({ onClose, onCreated }: { onClose: () => void; onCreated: (created: { id: string; name: string }) => void }) {
   const [name, setName] = React.useState("");
   const [prefecture, setPrefecture] = React.useState("");
   const [budget, setBudget] = React.useState("2000000");
@@ -709,8 +633,11 @@ function MuniModal({ onClose, onCreated }: { onClose: () => void; onCreated: () 
     if (!name.trim() || !prefecture.trim()) { setErr("自治体名・都道府県は必須です"); return; }
     setBusy(true); setErr("");
     try {
-      await apiPost("/api/super/municipalities", { name: name.trim(), prefecture: prefecture.trim(), annualBudget: Number(budget) || undefined });
-      onCreated();
+      const created = await apiPost<{ id: string; name: string; prefecture: string }>(
+        "/api/super/municipalities",
+        { name: name.trim(), prefecture: prefecture.trim(), annualBudget: Number(budget) || undefined }
+      );
+      onCreated({ id: created.id, name: created.name });
     } catch (e) { setErr((e as Error).message); setBusy(false); }
   }
 
@@ -853,41 +780,5 @@ function StatCard({
       </div>
       <div className="mt-1 text-2xl font-bold tabular-nums">{decimals ? value.toFixed(1) : value}</div>
     </div>
-  );
-}
-
-function StatusBadge({ status }: { status: string }) {
-  const map: Record<string, string> = {
-    active: "bg-emerald-50 text-emerald-700",
-    retired: "bg-slate-100 text-slate-500",
-    suspended: "bg-red-50 text-red-700",
-  };
-  return (
-    <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${map[status] ?? "bg-slate-100 text-slate-500"}`}>
-      {status}
-    </span>
-  );
-}
-
-function Select({
-  value,
-  onChange,
-  label,
-  children,
-}: {
-  value: string;
-  onChange: (v: string) => void;
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <select
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-[12px] text-slate-700"
-    >
-      <option value="">{label}</option>
-      {children}
-    </select>
   );
 }

--- a/src/app/super/_app.tsx
+++ b/src/app/super/_app.tsx
@@ -163,7 +163,7 @@ export function SuperApp() {
       )}
       {/* #65 管理者招待モーダル */}
       {inviteFor && (
-        <InviteModal muni={inviteFor} onClose={() => setInviteFor(null)} />
+        <InviteModal muni={inviteFor} onClose={() => setInviteFor(null)} onDone={loadOverview} />
       )}
 
       {/* #66 自治体ドリルダウン スライドオーバー */}
@@ -729,20 +729,45 @@ function MuniEditModal({
   );
 }
 
-function InviteModal({ muni, onClose }: { muni: { id: string; name: string }; onClose: () => void }) {
+function InviteModal({ muni, onClose, onDone }: { muni: { id: string; name: string }; onClose: () => void; onDone?: () => void }) {
+  // #113: 新規招待 / 既存ユーザー昇格 の2モード
+  const [mode, setMode] = React.useState<"new" | "promote">("new");
   const [email, setEmail] = React.useState("");
   const [name, setName] = React.useState("");
   const [busy, setBusy] = React.useState(false);
   const [err, setErr] = React.useState("");
   const [url, setUrl] = React.useState<string | null>(null);
+  const [promoted, setPromoted] = React.useState<string | null>(null);
   const [copied, setCopied] = React.useState(false);
 
-  async function submit() {
+  // 昇格候補: 対象自治体に所属し、まだ admin/super でない既存ユーザー
+  const [candidates, setCandidates] = React.useState<SuperUserRow[] | null>(null);
+  const [selectedId, setSelectedId] = React.useState("");
+
+  React.useEffect(() => {
+    if (mode !== "promote" || candidates !== null) return;
+    apiGet<SuperUserRow[]>(`/api/super/users?municipalityId=${muni.id}`)
+      .then((rows) => setCandidates(rows.filter((u) => u.role !== "admin" && u.role !== "super")))
+      .catch(() => setErr("既存ユーザーの取得に失敗しました"));
+  }, [mode, candidates, muni.id]);
+
+  async function submitInvite() {
     if (!email.trim() || !name.trim()) { setErr("メール・氏名は必須です"); return; }
     setBusy(true); setErr("");
     try {
       const res = await apiPost<{ url: string }>(`/api/super/municipalities/${muni.id}/admins`, { email: email.trim(), name: name.trim() });
       setUrl(res.url);
+      onDone?.();
+    } catch (e) { setErr((e as Error).message); } finally { setBusy(false); }
+  }
+
+  async function submitPromote() {
+    if (!selectedId) { setErr("昇格するユーザーを選択してください"); return; }
+    setBusy(true); setErr("");
+    try {
+      const updated = await apiPatch<SuperUserRow>(`/api/super/users/${selectedId}`, { role: "admin" });
+      setPromoted(updated.name);
+      onDone?.();
     } catch (e) { setErr((e as Error).message); } finally { setBusy(false); }
   }
 
@@ -753,8 +778,15 @@ function InviteModal({ muni, onClose }: { muni: { id: string; name: string }; on
     setTimeout(() => setCopied(false), 1500);
   }
 
+  function switchMode(next: "new" | "promote") {
+    setErr(""); setMode(next);
+  }
+
+  const tabCls = (active: boolean) =>
+    `flex-1 rounded-lg px-3 py-2 text-[12px] font-bold ${active ? "bg-slate-900 text-white" : "bg-slate-100 text-slate-600"}`;
+
   return (
-    <Modal title={`${muni.name} の管理者を招待`} onClose={onClose}>
+    <Modal title={`${muni.name} の管理者を設定`} onClose={onClose}>
       {url ? (
         <div className="space-y-3">
           <p className="text-[13px] text-slate-600">招待リンクを発行しました。この URL を管理者に渡してください(7日間有効)。</p>
@@ -766,14 +798,49 @@ function InviteModal({ muni, onClose }: { muni: { id: string; name: string }; on
           </div>
           <button onClick={onClose} className="w-full rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-bold text-slate-700">閉じる</button>
         </div>
+      ) : promoted ? (
+        <div className="space-y-3">
+          <p className="text-[13px] text-slate-600">「{promoted}」を {muni.name} の管理者(admin)に昇格しました。</p>
+          <button onClick={onClose} className="w-full rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-bold text-slate-700">閉じる</button>
+        </div>
       ) : (
         <div className="space-y-3">
-          <Field label="管理者の氏名"><input value={name} onChange={(e) => setName(e.target.value)} placeholder="例: 山田 太郎" className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" /></Field>
-          <Field label="メールアドレス"><input value={email} onChange={(e) => setEmail(e.target.value)} type="email" placeholder="admin@example.jp" className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" /></Field>
-          {err && <p className="text-[12px] text-rose-500">{err}</p>}
-          <button onClick={submit} disabled={busy} className="w-full rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-bold text-white disabled:opacity-40">
-            {busy ? "発行中…" : "招待リンクを発行"}
-          </button>
+          <div className="flex gap-2">
+            <button onClick={() => switchMode("new")} className={tabCls(mode === "new")}>新規招待</button>
+            <button onClick={() => switchMode("promote")} className={tabCls(mode === "promote")}>既存ユーザーを昇格</button>
+          </div>
+
+          {mode === "new" ? (
+            <>
+              <Field label="管理者の氏名"><input value={name} onChange={(e) => setName(e.target.value)} placeholder="例: 山田 太郎" className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" /></Field>
+              <Field label="メールアドレス"><input value={email} onChange={(e) => setEmail(e.target.value)} type="email" placeholder="admin@example.jp" className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" /></Field>
+              {err && <p className="text-[12px] text-rose-500">{err}</p>}
+              <button onClick={submitInvite} disabled={busy} className="w-full rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-bold text-white disabled:opacity-40">
+                {busy ? "発行中…" : "招待リンクを発行"}
+              </button>
+            </>
+          ) : (
+            <>
+              {candidates === null ? (
+                <p className="text-[12px] text-slate-500">読み込み中…</p>
+              ) : candidates.length === 0 ? (
+                <p className="text-[12px] text-slate-500">この自治体に昇格できる既存ユーザーがいません。「新規招待」を使ってください。</p>
+              ) : (
+                <Field label="昇格するユーザー">
+                  <select value={selectedId} onChange={(e) => setSelectedId(e.target.value)} className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm">
+                    <option value="">選択してください</option>
+                    {candidates.map((u) => (
+                      <option key={u.id} value={u.id}>{u.name}({u.email} / {u.role})</option>
+                    ))}
+                  </select>
+                </Field>
+              )}
+              {err && <p className="text-[12px] text-rose-500">{err}</p>}
+              <button onClick={submitPromote} disabled={busy || !candidates?.length} className="w-full rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-bold text-white disabled:opacity-40">
+                {busy ? "昇格中…" : "admin に昇格"}
+              </button>
+            </>
+          )}
         </div>
       )}
     </Modal>

--- a/src/app/super/_app.tsx
+++ b/src/app/super/_app.tsx
@@ -18,6 +18,7 @@ import {
   TrendingUp,
   TrendingDown,
   Trash2,
+  Pencil,
 } from "lucide-react";
 import type {
   SuperMuniDetail,
@@ -164,6 +165,8 @@ export function SuperApp() {
           detail={detail}
           error={detailErr}
           onClose={() => setDetailId(null)}
+          onReload={() => { if (detailId) openDetail(detailId); loadOverview(); }}
+          onAfterDelete={() => { setDetailId(null); loadOverview(); }}
         />
       )}
     </main>
@@ -263,11 +266,31 @@ function DetailSheet({
   detail,
   error,
   onClose,
+  onReload,
+  onAfterDelete,
 }: {
   detail: SuperMuniDetail | null;
   error: string | null;
   onClose: () => void;
+  onReload: () => void;
+  onAfterDelete: () => void;
 }) {
+  const [editing, setEditing] = React.useState(false);
+  const [opErr, setOpErr] = React.useState<string | null>(null);
+
+  async function remove() {
+    if (!detail) return;
+    if (!window.confirm(`自治体「${detail.municipality.name}」を削除します。元に戻せません。よろしいですか?`)) return;
+    setOpErr(null);
+    try {
+      await apiDelete(`/api/super/municipalities/${detail.municipality.id}`);
+      onAfterDelete();
+    } catch (e) {
+      // 所属ユーザーが居る場合はサーバ側で 409。メッセージを表示。
+      setOpErr(e instanceof Error ? e.message : "削除に失敗しました");
+    }
+  }
+
   return (
     <div className="fixed inset-0 z-40 flex justify-end">
       <div className="absolute inset-0 bg-slate-900/30" onClick={onClose} />
@@ -283,17 +306,43 @@ function DetailSheet({
         )}
         {detail && (
           <div className="p-6">
-            <div className="mb-6 flex items-start justify-between">
+            <div className="mb-6 flex items-start justify-between gap-3">
               <div>
                 <div className="text-[17px] font-bold">{detail.municipality.name}</div>
                 <div className="mt-0.5 text-[12px] text-slate-500">
                   {detail.municipality.prefecture}・年間予算 {detail.municipality.annualBudget.toLocaleString()} 円
                 </div>
               </div>
-              <button onClick={onClose} className="text-slate-400 hover:text-slate-900">
-                <X className="h-5 w-5" />
-              </button>
+              <div className="flex items-center gap-1.5">
+                <button
+                  onClick={() => { setOpErr(null); setEditing(true); }}
+                  className="inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-[11px] font-semibold text-slate-700 hover:bg-slate-100"
+                >
+                  <Pencil className="h-3 w-3" /> 編集
+                </button>
+                <button
+                  onClick={remove}
+                  className="inline-flex items-center gap-1 rounded-md border border-red-200 px-2 py-1 text-[11px] font-semibold text-red-600 hover:bg-red-50"
+                >
+                  <Trash2 className="h-3 w-3" /> 削除
+                </button>
+                <button onClick={onClose} className="ml-1 text-slate-400 hover:text-slate-900">
+                  <X className="h-5 w-5" />
+                </button>
+              </div>
             </div>
+
+            {opErr && (
+              <div className="mb-4 rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-[12px] text-red-700">{opErr}</div>
+            )}
+
+            {editing && (
+              <MuniEditModal
+                muni={detail.municipality}
+                onClose={() => setEditing(false)}
+                onSaved={() => { setEditing(false); onReload(); }}
+              />
+            )}
 
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
               <StatCard icon={<Users className="h-4 w-4" />} label="隊員" value={detail.members.length} />
@@ -674,6 +723,49 @@ function MuniModal({ onClose, onCreated }: { onClose: () => void; onCreated: () 
         {err && <p className="text-[12px] text-rose-500">{err}</p>}
         <button onClick={submit} disabled={busy} className="w-full rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-bold text-white disabled:opacity-40">
           {busy ? "作成中…" : "作成する"}
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+function MuniEditModal({
+  muni,
+  onClose,
+  onSaved,
+}: {
+  muni: { id: string; name: string; prefecture: string; annualBudget: number };
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [name, setName] = React.useState(muni.name);
+  const [prefecture, setPrefecture] = React.useState(muni.prefecture);
+  const [budget, setBudget] = React.useState(String(muni.annualBudget));
+  const [busy, setBusy] = React.useState(false);
+  const [err, setErr] = React.useState("");
+
+  async function submit() {
+    if (!name.trim() || !prefecture.trim()) { setErr("自治体名・都道府県は必須です"); return; }
+    setBusy(true); setErr("");
+    try {
+      await apiPatch(`/api/super/municipalities/${muni.id}`, {
+        name: name.trim(),
+        prefecture: prefecture.trim(),
+        annualBudget: Number(budget) || 0,
+      });
+      onSaved();
+    } catch (e) { setErr((e as Error).message); setBusy(false); }
+  }
+
+  return (
+    <Modal title="自治体を編集" onClose={onClose}>
+      <div className="space-y-3">
+        <Field label="自治体名"><input value={name} onChange={(e) => setName(e.target.value)} className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" /></Field>
+        <Field label="都道府県"><input value={prefecture} onChange={(e) => setPrefecture(e.target.value)} className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" /></Field>
+        <Field label="年間活動費枠(円)"><input value={budget} onChange={(e) => setBudget(e.target.value)} inputMode="numeric" className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" /></Field>
+        {err && <p className="text-[12px] text-rose-500">{err}</p>}
+        <button onClick={submit} disabled={busy} className="w-full rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-bold text-white disabled:opacity-40">
+          {busy ? "保存中…" : "保存する"}
         </button>
       </div>
     </Modal>

--- a/src/app/super/_app.tsx
+++ b/src/app/super/_app.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { apiGet, apiPost, apiPatch } from "@/lib/api/client";
+import { apiGet, apiPost, apiPatch, apiDelete } from "@/lib/api/client";
 import {
   Building2,
   Users,
@@ -17,6 +17,7 @@ import {
   ClipboardCheck,
   TrendingUp,
   TrendingDown,
+  Trash2,
 } from "lucide-react";
 import type {
   SuperMuniDetail,
@@ -432,6 +433,17 @@ function AccountsTab({ municipalities }: { municipalities: MuniRow[] }) {
     }
   }
 
+  async function remove(u: SuperUserRow) {
+    if (!window.confirm(`「${u.name}」(${u.email})を削除します。元に戻せません。よろしいですか?`)) return;
+    try {
+      await apiDelete(`/api/super/users/${u.id}`);
+      setUsers((prev) => (prev ? prev.filter((x) => x.id !== u.id) : prev));
+    } catch (e) {
+      // 自分自身の削除はサーバ側で 400 ブロック。メッセージを表示。
+      setErr(e instanceof Error ? e.message : "削除に失敗しました");
+    }
+  }
+
   return (
     <>
       <div className="mb-4 flex flex-wrap gap-2">
@@ -460,6 +472,7 @@ function AccountsTab({ municipalities }: { municipalities: MuniRow[] }) {
               <th className="px-3 py-2.5 text-left">role</th>
               <th className="px-3 py-2.5 text-left">status</th>
               <th className="px-3 py-2.5 text-right">活動記録</th>
+              <th className="px-3 py-2.5 text-right">操作</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-100">
@@ -498,13 +511,22 @@ function AccountsTab({ municipalities }: { municipalities: MuniRow[] }) {
                   </select>
                 </td>
                 <td className="px-3 py-2 text-right tabular-nums">{u.activityLogs}</td>
+                <td className="px-3 py-2 text-right">
+                  <button
+                    onClick={() => remove(u)}
+                    title="このユーザーを削除"
+                    className="inline-flex items-center gap-1 rounded-md border border-red-200 px-2 py-1 text-[11px] font-semibold text-red-600 hover:bg-red-50"
+                  >
+                    <Trash2 className="h-3 w-3" /> 削除
+                  </button>
+                </td>
               </tr>
             ))}
             {users && users.length === 0 && (
-              <tr><td colSpan={6} className="px-3 py-8 text-center text-slate-400">該当ユーザーがいません</td></tr>
+              <tr><td colSpan={7} className="px-3 py-8 text-center text-slate-400">該当ユーザーがいません</td></tr>
             )}
             {!users && !err && (
-              <tr><td colSpan={6} className="px-3 py-8 text-center text-slate-400">読み込み中…</td></tr>
+              <tr><td colSpan={7} className="px-3 py-8 text-center text-slate-400">読み込み中…</td></tr>
             )}
           </tbody>
         </table>

--- a/src/app/super/_app.tsx
+++ b/src/app/super/_app.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 import type {
   SuperMuniDetail,
+  SuperUserRow,
   SuperAnalytics,
 } from "@/lib/db/repositories/types";
 
@@ -50,8 +51,8 @@ type Overview = {
 type Tab = "overview" | "analytics";
 
 // #119: 自治体詳細でのアカウント編集に使う選択肢
+const ROLE_OPTS = ["member", "manager", "admin", "super"];
 const STATUS_OPTS = ["active", "retired", "suspended"];
-const STAFF_ROLE_OPTS = ["manager", "admin"];
 
 export function SuperApp() {
   const [data, setData] = React.useState<Overview | null>(null);
@@ -173,6 +174,8 @@ export function SuperApp() {
           onClose={() => setDetailId(null)}
           onReload={() => { if (detailId) openDetail(detailId); loadOverview(); }}
           onAfterDelete={() => { setDetailId(null); loadOverview(); }}
+          municipalities={data?.municipalities ?? []}
+          onOverviewRefresh={loadOverview}
         />
       )}
     </main>
@@ -274,12 +277,16 @@ function DetailSheet({
   onClose,
   onReload,
   onAfterDelete,
+  municipalities,
+  onOverviewRefresh,
 }: {
   detail: SuperMuniDetail | null;
   error: string | null;
   onClose: () => void;
   onReload: () => void;
   onAfterDelete: () => void;
+  municipalities: MuniRow[];
+  onOverviewRefresh: () => void;
 }) {
   const [editing, setEditing] = React.useState(false);
   const [opErr, setOpErr] = React.useState<string | null>(null);
@@ -293,29 +300,6 @@ function DetailSheet({
       onAfterDelete();
     } catch (e) {
       // 所属ユーザーが居る場合はサーバ側で 409。メッセージを表示。
-      setOpErr(e instanceof Error ? e.message : "削除に失敗しました");
-    }
-  }
-
-  // #119: 自治体ごとのアカウント管理(role/status 変更・削除)を詳細内で行う
-  async function patchUser(id: string, body: { role?: string; status?: string }) {
-    setOpErr(null);
-    try {
-      await apiPatch(`/api/super/users/${id}`, body);
-      onReload();
-    } catch (e) {
-      setOpErr(e instanceof Error ? e.message : "更新に失敗しました");
-    }
-  }
-
-  async function removeUser(id: string, name: string) {
-    if (!window.confirm(`「${name}」を削除します。元に戻せません。よろしいですか?`)) return;
-    setOpErr(null);
-    try {
-      await apiDelete(`/api/super/users/${id}`);
-      onReload();
-    } catch (e) {
-      // 自分自身の削除はサーバ側で 400 ブロック。
       setOpErr(e instanceof Error ? e.message : "削除に失敗しました");
     }
   }
@@ -380,99 +364,13 @@ function DetailSheet({
               <StatCard icon={<ClipboardCheck className="h-4 w-4" />} label="保留承認" value={detail.pendingApprovals.total} />
             </div>
 
-            {/* 隊員一覧 */}
-            <h3 className="mt-6 mb-2 text-[13px] font-bold text-slate-700">隊員一覧</h3>
-            <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
-              <table className="w-full text-[13px]">
-                <thead className="bg-slate-50 text-[11px] uppercase text-slate-500">
-                  <tr>
-                    <th className="px-3 py-2 text-left">名前</th>
-                    <th className="px-3 py-2 text-left">役割</th>
-                    <th className="px-3 py-2 text-left">任期</th>
-                    <th className="px-3 py-2 text-left">着任日</th>
-                    <th className="px-3 py-2 text-left">状態</th>
-                    <th className="px-3 py-2 text-right">操作</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-slate-100">
-                  {detail.members.map((m) => (
-                    <tr key={m.id}>
-                      <td className="px-3 py-2 font-medium">{m.name}</td>
-                      <td className="px-3 py-2 text-slate-500">{m.role}</td>
-                      <td className="px-3 py-2 text-slate-500">{m.term}</td>
-                      <td className="px-3 py-2 text-slate-500">{m.startedAt}</td>
-                      <td className="px-3 py-2">
-                        <select
-                          value={m.status}
-                          onChange={(e) => patchUser(m.id, { status: e.target.value })}
-                          className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-[12px]"
-                        >
-                          {STATUS_OPTS.map((s) => <option key={s} value={s}>{s}</option>)}
-                        </select>
-                      </td>
-                      <td className="px-3 py-2 text-right">
-                        <button
-                          onClick={() => removeUser(m.id, m.name)}
-                          title="この隊員を削除"
-                          className="inline-flex items-center gap-1 rounded-md border border-red-200 px-2 py-1 text-[11px] font-semibold text-red-600 hover:bg-red-50"
-                        >
-                          <Trash2 className="h-3 w-3" /> 削除
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                  {detail.members.length === 0 && (
-                    <tr><td colSpan={6} className="px-3 py-6 text-center text-slate-400">隊員がいません</td></tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
-
-            {/* 職員一覧 */}
-            <h3 className="mt-6 mb-2 text-[13px] font-bold text-slate-700">職員一覧</h3>
-            <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
-              <table className="w-full text-[13px]">
-                <thead className="bg-slate-50 text-[11px] uppercase text-slate-500">
-                  <tr>
-                    <th className="px-3 py-2 text-left">名前</th>
-                    <th className="px-3 py-2 text-left">役職</th>
-                    <th className="px-3 py-2 text-left">所属課</th>
-                    <th className="px-3 py-2 text-left">role</th>
-                    <th className="px-3 py-2 text-right">操作</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-slate-100">
-                  {detail.staff.map((s) => (
-                    <tr key={s.id}>
-                      <td className="px-3 py-2 font-medium">{s.name}</td>
-                      <td className="px-3 py-2 text-slate-500">{s.title}</td>
-                      <td className="px-3 py-2 text-slate-500">{s.dept}</td>
-                      <td className="px-3 py-2">
-                        <select
-                          value={s.role}
-                          onChange={(e) => patchUser(s.id, { role: e.target.value })}
-                          className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-[12px]"
-                        >
-                          {STAFF_ROLE_OPTS.map((r) => <option key={r} value={r}>{r}</option>)}
-                        </select>
-                      </td>
-                      <td className="px-3 py-2 text-right">
-                        <button
-                          onClick={() => removeUser(s.id, s.name)}
-                          title="この職員を削除"
-                          className="inline-flex items-center gap-1 rounded-md border border-red-200 px-2 py-1 text-[11px] font-semibold text-red-600 hover:bg-red-50"
-                        >
-                          <Trash2 className="h-3 w-3" /> 削除
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                  {detail.staff.length === 0 && (
-                    <tr><td colSpan={5} className="px-3 py-6 text-center text-slate-400">職員がいません</td></tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
+            {/* #119: 自治体内アカウント管理(role/状態/所属変更・削除) */}
+            <h3 className="mt-6 mb-2 text-[13px] font-bold text-slate-700">アカウント</h3>
+            <MuniAccounts
+              municipalityId={detail.municipality.id}
+              municipalities={municipalities}
+              onOverviewRefresh={onOverviewRefresh}
+            />
 
             {/* 最近の保留承認 */}
             <h3 className="mt-6 mb-2 text-[13px] font-bold text-slate-700">最近の保留承認</h3>
@@ -505,6 +403,136 @@ function DetailSheet({
         )}
       </div>
     </div>
+  );
+}
+
+/* ---------------- 自治体内アカウント管理(#119) ---------------- */
+
+// 自治体ドリルダウン内で、その自治体の全ユーザーを role/状態/所属変更・削除する。
+// 変更はローカル state を楽観更新し、概要のカウントのみ再取得(詳細の再取得ちらつきを避ける)。
+function MuniAccounts({
+  municipalityId,
+  municipalities,
+  onOverviewRefresh,
+}: {
+  municipalityId: string;
+  municipalities: MuniRow[];
+  onOverviewRefresh: () => void;
+}) {
+  const [users, setUsers] = React.useState<SuperUserRow[] | null>(null);
+  const [err, setErr] = React.useState<string | null>(null);
+
+  const load = React.useCallback(() => {
+    apiGet<SuperUserRow[]>(`/api/super/users?municipalityId=${municipalityId}`)
+      .then(setUsers)
+      .catch(() => setErr("ユーザーの取得に失敗しました"));
+  }, [municipalityId]);
+
+  React.useEffect(() => { load(); }, [load]);
+
+  async function patch(id: string, body: { role?: string; status?: string; municipalityId?: string }) {
+    setErr(null);
+    try {
+      const updated = await apiPatch<SuperUserRow>(`/api/super/users/${id}`, body);
+      // 所属を別自治体へ移したらこの一覧からは外す
+      setUsers((prev) =>
+        prev
+          ? prev.flatMap((u) => (u.id !== id ? [u] : updated.municipalityId === municipalityId ? [updated] : []))
+          : prev
+      );
+      onOverviewRefresh();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "更新に失敗しました");
+      load(); // 失敗時(自己変更ブロック等)はサーバ状態へ戻す
+    }
+  }
+
+  async function remove(u: SuperUserRow) {
+    if (!window.confirm(`「${u.name}」(${u.email})を削除します。元に戻せません。よろしいですか?`)) return;
+    setErr(null);
+    try {
+      await apiDelete(`/api/super/users/${u.id}`);
+      setUsers((prev) => (prev ? prev.filter((x) => x.id !== u.id) : prev));
+      onOverviewRefresh();
+    } catch (e) {
+      // 自分自身の削除はサーバ側で 400 ブロック。
+      setErr(e instanceof Error ? e.message : "削除に失敗しました");
+    }
+  }
+
+  return (
+    <>
+      {err && <div className="mb-3 rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-[12px] text-red-700">{err}</div>}
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+        <table className="w-full text-[13px]">
+          <thead className="bg-slate-50 text-[11px] uppercase text-slate-500">
+            <tr>
+              <th className="px-3 py-2 text-left">氏名</th>
+              <th className="px-3 py-2 text-left">role</th>
+              <th className="px-3 py-2 text-left">状態</th>
+              <th className="px-3 py-2 text-left">所属</th>
+              <th className="px-3 py-2 text-right">活動</th>
+              <th className="px-3 py-2 text-right">操作</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {(users ?? []).map((u) => (
+              <tr key={u.id} className="hover:bg-slate-50">
+                <td className="px-3 py-2">
+                  <div className="font-medium">{u.name}</div>
+                  <div className="text-[11px] text-slate-400">{u.email}</div>
+                </td>
+                <td className="px-3 py-2">
+                  <select
+                    value={u.role}
+                    onChange={(e) => patch(u.id, { role: e.target.value })}
+                    className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-[12px]"
+                  >
+                    {ROLE_OPTS.map((r) => <option key={r} value={r}>{r}</option>)}
+                  </select>
+                </td>
+                <td className="px-3 py-2">
+                  <select
+                    value={u.status}
+                    onChange={(e) => patch(u.id, { status: e.target.value })}
+                    className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-[12px]"
+                  >
+                    {STATUS_OPTS.map((s) => <option key={s} value={s}>{s}</option>)}
+                  </select>
+                </td>
+                <td className="px-3 py-2">
+                  <select
+                    value={u.municipalityId ?? ""}
+                    onChange={(e) => patch(u.id, { municipalityId: e.target.value })}
+                    className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-[12px]"
+                  >
+                    {municipalities.map((m) => (
+                      <option key={m.id} value={m.id}>{m.name}</option>
+                    ))}
+                  </select>
+                </td>
+                <td className="px-3 py-2 text-right tabular-nums">{u.activityLogs}</td>
+                <td className="px-3 py-2 text-right">
+                  <button
+                    onClick={() => remove(u)}
+                    title="このユーザーを削除"
+                    className="inline-flex items-center gap-1 rounded-md border border-red-200 px-2 py-1 text-[11px] font-semibold text-red-600 hover:bg-red-50"
+                  >
+                    <Trash2 className="h-3 w-3" /> 削除
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {users && users.length === 0 && (
+              <tr><td colSpan={6} className="px-3 py-8 text-center text-slate-400">ユーザーがいません</td></tr>
+            )}
+            {!users && !err && (
+              <tr><td colSpan={6} className="px-3 py-8 text-center text-slate-400">読み込み中…</td></tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </>
   );
 }
 

--- a/src/lib/db/__tests__/super.test.ts
+++ b/src/lib/db/__tests__/super.test.ts
@@ -27,6 +27,38 @@ describe("super.createMunicipality", () => {
   });
 });
 
+describe("super.updateMunicipality", () => {
+  it("名称・都道府県・年間予算を部分更新できる", async () => {
+    const created = await sqliteRepos.super.createMunicipality({ name: "旧名町", prefecture: "京都府" });
+    const updated = await sqliteRepos.super.updateMunicipality(created.id, { name: "新名町", annualBudget: 3000000 });
+
+    expect(updated).not.toBeNull();
+    expect(updated?.name).toBe("新名町");
+    expect(updated?.prefecture).toBe("京都府"); // 未指定は据え置き
+    const contract = await sqliteRepos.super.getContract(created.id);
+    expect(contract?.annualBudget).toBe(3000000);
+  });
+
+  it("存在しない ID は null を返す", async () => {
+    const r = await sqliteRepos.super.updateMunicipality("muni_does_not_exist", { name: "x" });
+    expect(r).toBeNull();
+  });
+});
+
+describe("super.deleteMunicipality", () => {
+  it("自治体を削除すると overview から消える", async () => {
+    const created = await sqliteRepos.super.createMunicipality({ name: "消える町", prefecture: "兵庫県" });
+    const before = (await sqliteRepos.super.overview()).totals.municipalities;
+
+    await sqliteRepos.super.deleteMunicipality(created.id);
+
+    const after = await sqliteRepos.super.overview();
+    expect(after.totals.municipalities).toBe(before - 1);
+    expect(after.municipalities.map((m) => m.id)).not.toContain(created.id);
+    expect(await sqliteRepos.super.municipalityDetail(created.id)).toBeNull();
+  });
+});
+
 describe("super.createAdminInvite", () => {
   it("admin を pre-provision し、招待トークンを発行する", async () => {
     const muni = await sqliteRepos.super.createMunicipality({ name: "招待先町", prefecture: "兵庫県" });

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -162,6 +162,26 @@ export const sqliteRepos: Repos = {
       return { id, name: m.name, prefecture: m.prefecture };
     },
 
+    async updateMunicipality(id, patch) {
+      run(
+        `UPDATE municipalities SET
+           name=COALESCE(?,name),
+           prefecture=COALESCE(?,prefecture),
+           annual_budget=COALESCE(?,annual_budget)
+         WHERE id=?`,
+        [patch.name ?? null, patch.prefecture ?? null, patch.annualBudget ?? null, id]
+      );
+      const m = get<{ id: string; name: string; prefecture: string }>(
+        "SELECT id, name, prefecture FROM municipalities WHERE id=?",
+        [id]
+      );
+      return m ?? null;
+    },
+
+    async deleteMunicipality(id): Promise<void> {
+      run("DELETE FROM municipalities WHERE id=?", [id]);
+    },
+
     async createAdminInvite(a) {
       const muni = get<{ name: string }>("SELECT name FROM municipalities WHERE id=?", [a.municipalityId]);
       // admin を pre-provision(/api/auth/me が email で auth_id を紐づけられるよう先に行を作る)

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -235,17 +235,21 @@ export const supabaseRepos: Repos = {
       if (patch.name !== undefined) fields.name = patch.name;
       if (patch.prefecture !== undefined) fields.prefecture = patch.prefecture;
       if (patch.annualBudget !== undefined) fields.annual_budget = patch.annualBudget;
-      const { data } = await supabase()
+      const { data, error } = await supabase()
         .from("municipalities")
         .update(fields)
         .eq("id", id)
         .select("id,name,prefecture")
         .maybeSingle();
+      // エラーは握りつぶさず投げる(誤った 404 を防ぎ、sqlite の挙動に揃える)
+      if (error) throw error;
       return data ? { id: data.id, name: data.name, prefecture: data.prefecture } : null;
     },
 
     async deleteMunicipality(id): Promise<void> {
-      await supabase().from("municipalities").delete().eq("id", id);
+      // FK/RLS で失敗した場合に「成功扱い」にしない
+      const { error } = await supabase().from("municipalities").delete().eq("id", id);
+      if (error) throw error;
     },
 
     async createAdminInvite(a) {

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -230,6 +230,24 @@ export const supabaseRepos: Repos = {
       return { id: data!.id, name: data!.name, prefecture: data!.prefecture };
     },
 
+    async updateMunicipality(id, patch) {
+      const fields: Record<string, unknown> = {};
+      if (patch.name !== undefined) fields.name = patch.name;
+      if (patch.prefecture !== undefined) fields.prefecture = patch.prefecture;
+      if (patch.annualBudget !== undefined) fields.annual_budget = patch.annualBudget;
+      const { data } = await supabase()
+        .from("municipalities")
+        .update(fields)
+        .eq("id", id)
+        .select("id,name,prefecture")
+        .maybeSingle();
+      return data ? { id: data.id, name: data.name, prefecture: data.prefecture } : null;
+    },
+
+    async deleteMunicipality(id): Promise<void> {
+      await supabase().from("municipalities").delete().eq("id", id);
+    },
+
     async createAdminInvite(a) {
       const { data: muni } = await supabase().from("municipalities").select("name").eq("id", a.municipalityId).maybeSingle();
       // admin を pre-provision(/api/auth/me が email で auth_id を紐づけられるよう先に行を作る)

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -168,6 +168,10 @@ export interface Repos {
     overview(): Promise<SuperOverview>;
     /** #65: 運営者が自治体を新規作成 */
     createMunicipality(m: { name: string; prefecture: string; annualBudget?: number }): Promise<{ id: string; name: string; prefecture: string }>;
+    /** 自治体の名称/都道府県/年間予算を部分更新 */
+    updateMunicipality(id: string, patch: { name?: string; prefecture?: string; annualBudget?: number }): Promise<{ id: string; name: string; prefecture: string } | null>;
+    /** 自治体を削除(所属ユーザーの有無チェックは呼び出し側で行う) */
+    deleteMunicipality(id: string): Promise<void>;
     /** #65: 指定自治体の admin を pre-provision + 招待トークン発行(url は Route 側で付与) */
     createAdminInvite(a: { municipalityId: string; email: string; name: string; createdBy: string }): Promise<{ token: string; expiresAt: string }>;
     /** #66: 自治体ドリルダウン詳細(隊員・職員・活動・保留承認) */


### PR DESCRIPTION
## 概要
運営者(super)管理画面の **編集・削除/アカウント管理 UX** を一括整理し、コードレビュー(high)の確定バグを修正した。

## 主な変更
1. **自治体の編集・削除**(詳細パネル)。削除は在籍ユーザーが居れば 409。API `/api/super/municipalities/[id]` に PATCH/DELETE、Repos に update/deleteMunicipality(3層)。
2. **アカウントタブ廃止 → 自治体詳細に統合(#119)**。詳細に全ユーザーの **role / 状態 / 所属変更 + 削除** ができる管理表(MuniAccounts)を追加。所属変更で「別自治体へ移動」も可能。
3. **作成 → 招待の連結(#113)**。自治体作成後そのまま「管理者を招待」を自動起動。既存ユーザーの admin 昇格は詳細の role 変更で可能。

## コードレビュー(high)で修正した確定バグ
- **削除が必ず 500**: `ok(null,204)` は NextResponse.json / クライアント res.json() 双方で例外 → `ok({ok:true})`(200)に変更(自治体・ユーザー両ルート)。
- 自治体編集の予算が空入力で 0 上書き → 数値バリデーション追加。
- 自治体削除の在籍判定が role=super を取りこぼし → `listUsers` で全ロール計上。
- supabase の update/deleteMunicipality がエラー握り潰し → throw(誤 404・偽成功防止)。
- 回帰(所属変更不可・隊員昇格不可・再取得ちらつき)→ MuniAccounts の統合管理表 + 楽観更新で解消。

## 検証
- `npx tsc --noEmit` クリーン / `npm test` → 5 files / 22 tests passed
- 編集は `src/app/super/` `src/app/api/super/` + 共有 repo の末尾追加のみ

## 対応 Issue
- #119(アカウントタブ廃止・自治体統合) / #113(作成→admin設定) / #89(ユーザー削除API)

## 既知の制限 / フォロー
- 詳細の統合管理表は自治体所属ユーザーのみ対象(未所属/他自治体は対象外。所属変更で移動は可能)。
- 「新規招待」は #74(招待 pre-provision 不具合)解消が前提。
- 分析の月判定 TZ は別 Issue #97。

🤖 Generated with [Claude Code](https://claude.com/claude-code)