### PR TITLE
fix(member): 活動時間0hの種類もタグ別サマリに表示 (#87)

### DIFF
--- a/src/app/member/_app.tsx
+++ b/src/app/member/_app.tsx
@@ -690,10 +690,12 @@ function MonthOverview({ ym, onDayTap }: { ym: string; onDayTap: (date: string) 
   for (const l of monthLogs) (byDate[l.date] ??= []).push(l);
 
   // 活動時間:種類別(積算棒) — ACTIVITY_TYPES 順を優先し、それ以外は末尾に追加
+  // #87: 記録があれば活動時間 0h の種類も一覧に出す(byType に載る=その月に1件以上記録あり)。
+  // 0h はバー区間こそ出ないが、凡例に「0h」で表示され「記録したのに消える」を防ぐ。
   const byType: Record<string, number> = {};
   for (const l of monthLogs) byType[l.type] = (byType[l.type] ?? 0) + l.hours;
   const typeOrder = [
-    ...ACTIVITY_TYPES.filter((t) => byType[t] > 0),
+    ...ACTIVITY_TYPES.filter((t) => byType[t] !== undefined),
     ...Object.keys(byType).filter((t) => !ACTIVITY_TYPES.includes(t)),
   ];
   const hoursProgress = Math.min(totalHours / MIN_MONTHLY_HOURS, 1);


### PR DESCRIPTION
## 概要
種類別の積算サマリで `byType[t] > 0` 絞り込みのため、記録はあるが合計0hの活動種類が凡例から消えていた(カスタム種類は表示される非対称も解消)。記録があれば0hでも凡例に表示する。

## 注意
スタックPR。base は #82/#86 (`feat/member-activity-save-fix`)。マージ順: #96 → 本PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)