### PR TITLE
feat(admin): #74 招待発行時に招待先ユーザーを pre-provision

### DIFF
--- a/src/app/admin/_app.tsx
+++ b/src/app/admin/_app.tsx
@@ -1353,6 +1353,7 @@ type InviteResult = { token: string; url: string; expiresAt: string };
 
 function InviteTab() {
   const [email, setEmail] = React.useState("");
+  const [name, setName] = React.useState("");
   const [role, setRole] = React.useState<string>("member");
   const [municipalityName, setMunicipalityName] = React.useState("新温泉町");
   const [result, setResult] = React.useState<InviteResult | null>(null);
@@ -1360,14 +1361,18 @@ function InviteTab() {
   const [sending, setSending] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
+  const canSubmit = !!email.trim() && !!name.trim();
+
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
+    if (!canSubmit) return;
     setSending(true);
     setError(null);
     setResult(null);
     try {
       const res = await apiPost<InviteResult>("/api/admin/invites", {
-        email: email.trim() || undefined,
+        email: email.trim(),
+        name: name.trim(),
         role,
         municipalityName: municipalityName.trim(),
       });
@@ -1397,16 +1402,28 @@ function InviteTab() {
       <h2 className="mb-1 text-[17px] font-bold text-slate-900">招待リンクを発行</h2>
       <p className="mb-5 text-[13px] text-slate-500">
         発行したリンクを招待したい相手に共有してください。リンクは 7 日間有効で、1 回のみ使用できます。
+        登録後すぐにログインできるよう、招待時にアカウントを準備します。
       </p>
 
       <form onSubmit={handleCreate} className="space-y-4">
         <div>
-          <label className="block text-[12px] font-medium text-slate-700 mb-1">メールアドレス(任意)</label>
+          <label className="block text-[12px] font-medium text-slate-700 mb-1">氏名</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="例:谷本 拓海"
+            className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-[14px] focus:border-slate-900 focus:outline-none"
+          />
+        </div>
+
+        <div>
+          <label className="block text-[12px] font-medium text-slate-700 mb-1">メールアドレス</label>
           <input
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            placeholder="指定すると登録時に固定されます"
+            placeholder="招待先のメールアドレス(登録時に固定されます)"
             className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-[14px] focus:border-slate-900 focus:outline-none"
           />
         </div>
@@ -1440,8 +1457,8 @@ function InviteTab() {
 
         <button
           type="submit"
-          disabled={sending}
-          className="inline-flex items-center gap-1.5 rounded-xl bg-slate-900 px-5 py-2.5 text-[14px] font-semibold text-white transition hover:bg-slate-700 disabled:opacity-60"
+          disabled={sending || !canSubmit}
+          className="inline-flex items-center gap-1.5 rounded-xl bg-slate-900 px-5 py-2.5 text-[14px] font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
         >
           <Plus className="h-3.5 w-3.5" />
           {sending ? "生成中…" : "招待リンクを生成"}

--- a/src/app/api/admin/approval-routes.test.ts
+++ b/src/app/api/admin/approval-routes.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+
+// 承認ルート検証(受入団体ステップは団体必須)。
+// UI 側(RouteEditSheet.canSave / PR#75)は host_org ステップに
+// hostOrganizationId を必須化している。その入力がデータ層まで
+// 欠落なく往復することを検証する(団体必須の前提が壊れていないこと)。
+
+describe("承認ルート 受入団体ステップ (#PR75 整合)", () => {
+  it("host_org ステップの hostOrganizationId が保存・取得で保持される", async () => {
+    const org = await sqliteRepos.hostOrgs.upsert({ name: "テスト受入団体", kind: "npo" });
+    expect(org.id).toBeTruthy();
+
+    const created = await sqliteRepos.routes.create({
+      name: "受入団体ルート",
+      kind: "expense",
+      steps: [
+        { stepNo: 1, approverType: "host_org", approverLabel: "受入団体", hostOrganizationId: org.id },
+        { stepNo: 2, approverType: "dept", approverLabel: "企画課" },
+      ],
+    });
+    expect(created).toBeTruthy();
+
+    const fetched = (await sqliteRepos.routes.list()).find((r) => r.id === created!.id);
+    expect(fetched).toBeTruthy();
+
+    const hostStep = fetched!.steps.find((s) => s.approverType === "host_org");
+    expect(hostStep, "host_org ステップが消えている").toBeTruthy();
+    expect(hostStep!.hostOrganizationId).toBe(org.id);
+
+    const deptStep = fetched!.steps.find((s) => s.approverType === "dept");
+    expect(deptStep!.approverLabel).toBe("企画課");
+  });
+});

--- a/src/app/api/admin/invites/invites.test.ts
+++ b/src/app/api/admin/invites/invites.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+import { GET } from "./[token]/route";
+
+// #74 招待リンク回帰テスト。
+// 「管理者を招待」ボタンで発行したトークンが、発行→検証→単回使用まで
+// 期待どおり動くことを sqlite シードに対して検証する(AUTH_PROVIDER=none)。
+//
+// createdBy はシード済みユーザー(m1)を使う。本番(Postgres)では
+// created_by が users(id) への FK なので、実在ユーザーを渡す必要がある。
+const ADMIN_ID = "m1";
+
+function reqFor(token: string) {
+  return new Request(`http://localhost/api/admin/invites/${token}/`);
+}
+
+describe("invites リポジトリ (#74 招待発行)", () => {
+  it("create が トークン と 7 日後の有効期限を採番する", async () => {
+    const before = Date.now();
+    const { token, expiresAt } = await sqliteRepos.invites.create({
+      email: "newadmin@example.jp",
+      role: "admin",
+      municipalityName: "新温泉町",
+      createdBy: ADMIN_ID,
+    });
+    expect(token).toMatch(/^[0-9a-f]{48}$/); // 24 byte hex
+    const ms = new Date(expiresAt).getTime() - before;
+    // おおよそ 7 日(誤差 1 分許容)
+    expect(ms).toBeGreaterThan(7 * 24 * 60 * 60 * 1000 - 60_000);
+    expect(ms).toBeLessThan(7 * 24 * 60 * 60 * 1000 + 60_000);
+  });
+
+  it("findByToken が 発行時の email / role / 自治体名 を返す", async () => {
+    const { token } = await sqliteRepos.invites.create({
+      email: "staff@town.example.jp",
+      role: "manager",
+      municipalityName: "香美町",
+      createdBy: ADMIN_ID,
+    });
+    const row = await sqliteRepos.invites.findByToken(token);
+    expect(row).not.toBeNull();
+    expect(row!.email).toBe("staff@town.example.jp");
+    expect(row!.role).toBe("manager");
+    expect(row!.municipalityName).toBe("香美町");
+    expect(row!.usedAt).toBeNull();
+  });
+
+  it("findByToken は 未知のトークンに null を返す", async () => {
+    expect(await sqliteRepos.invites.findByToken("deadbeef")).toBeNull();
+  });
+
+  it("markUsed は usedAt を設定し、二重呼び出しでも冪等", async () => {
+    const { token } = await sqliteRepos.invites.create({
+      email: null,
+      role: "member",
+      municipalityName: "新温泉町",
+      createdBy: ADMIN_ID,
+    });
+    await sqliteRepos.invites.markUsed(token);
+    const used = await sqliteRepos.invites.findByToken(token);
+    expect(used!.usedAt).not.toBeNull();
+    const firstUsedAt = used!.usedAt;
+    // 二度目は no-op(used_at IS NULL 条件)。例外を投げず値も変えない。
+    await sqliteRepos.invites.markUsed(token);
+    const again = await sqliteRepos.invites.findByToken(token);
+    expect(again!.usedAt).toBe(firstUsedAt);
+  });
+});
+
+describe("GET /api/admin/invites/[token] (#74 トークン検証)", () => {
+  it("有効なトークンは 200 と招待情報を返す", async () => {
+    const { token } = await sqliteRepos.invites.create({
+      email: "ok@example.jp",
+      role: "admin",
+      municipalityName: "新温泉町",
+      createdBy: ADMIN_ID,
+    });
+    const res = await GET(reqFor(token), { params: Promise.resolve({ token }) });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      email: "ok@example.jp",
+      role: "admin",
+      municipalityName: "新温泉町",
+    });
+  });
+
+  it("未知のトークンは 404", async () => {
+    const res = await GET(reqFor("nope"), { params: Promise.resolve({ token: "nope" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("使用済みトークンは 410", async () => {
+    const { token } = await sqliteRepos.invites.create({
+      email: null,
+      role: "manager",
+      municipalityName: "新温泉町",
+      createdBy: ADMIN_ID,
+    });
+    await sqliteRepos.invites.markUsed(token);
+    const res = await GET(reqFor(token), { params: Promise.resolve({ token }) });
+    expect(res.status).toBe(410);
+  });
+});

--- a/src/app/api/admin/invites/provision.test.ts
+++ b/src/app/api/admin/invites/provision.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+import { BUDGET_CATEGORIES, DEFAULT_ALLOCATION, currentFiscalYear } from "@/lib/budget";
+
+// #74 修正: 招待発行時に招待先 users 行を pre-provision する。
+// これにより /api/auth/me が email で auth_id を紐づけられ、招待後すぐログインできる。
+const ADMIN_ID = "m1";
+
+describe("invites.createProvisioned (#74 招待先の pre-provision)", () => {
+  it("管理者招待で users 行(role=admin)が作られ、トークンも発行される", async () => {
+    const { token } = await sqliteRepos.invites.createProvisioned({
+      email: "newadmin74@example.jp",
+      name: "招待 管理太郎",
+      role: "admin",
+      municipalityName: "新温泉町",
+      createdBy: ADMIN_ID,
+    });
+
+    // トークンは email 固定で発行される
+    const row = await sqliteRepos.invites.findByToken(token);
+    expect(row).not.toBeNull();
+    expect(row!.email).toBe("newadmin74@example.jp");
+    expect(row!.role).toBe("admin");
+
+    // role=admin の users 行が作られている。
+    const admins = await sqliteRepos.super.listUsers({ role: "admin" });
+    expect(admins.some((u) => u.email === "newadmin74@example.jp")).toBe(true);
+  });
+
+  it("職員招待で職員一覧に現れ、隊員一覧には現れない", async () => {
+    await sqliteRepos.invites.createProvisioned({
+      email: "newmgr74@example.jp",
+      name: "招待 職員花子",
+      role: "manager",
+      municipalityName: "新温泉町",
+      createdBy: ADMIN_ID,
+    });
+    const staff = await sqliteRepos.staff.list();
+    const members = await sqliteRepos.members.list();
+    expect(staff.some((s) => s.name === "招待 職員花子")).toBe(true);
+    expect(members.some((m) => m.name === "招待 職員花子")).toBe(false);
+  });
+
+  it("隊員招待で隊員行が作られ、当年度の既定予算枠が seed される", async () => {
+    await sqliteRepos.invites.createProvisioned({
+      email: "newmember74@example.jp",
+      name: "招待 隊員次郎",
+      role: "member",
+      municipalityName: "新温泉町",
+      createdBy: ADMIN_ID,
+    });
+    const members = await sqliteRepos.members.list();
+    const created = members.find((m) => m.name === "招待 隊員次郎");
+    expect(created, "隊員行が作られていない").toBeTruthy();
+
+    const lines = await sqliteRepos.budgets.summaryByUser(created!.id, currentFiscalYear());
+    for (const cat of BUDGET_CATEGORIES) {
+      const line = lines.find((l) => l.category === cat);
+      expect(line!.amountLimit).toBe(DEFAULT_ALLOCATION[cat] ?? 0);
+    }
+  });
+
+  it("同じ email で2回招待しても users 行は重複しない(冪等)", async () => {
+    const args = {
+      email: "dup74@example.jp",
+      name: "招待 重複三郎",
+      role: "member" as const,
+      municipalityName: "新温泉町",
+      createdBy: ADMIN_ID,
+    };
+    await sqliteRepos.invites.createProvisioned(args);
+    await sqliteRepos.invites.createProvisioned(args);
+
+    const members = await sqliteRepos.members.list();
+    const matches = members.filter((m) => m.name === "招待 重複三郎");
+    expect(matches.length).toBe(1);
+  });
+});

--- a/src/app/api/admin/invites/provision.test.ts
+++ b/src/app/api/admin/invites/provision.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { get, run } from "@/lib/db";
 import { sqliteRepos } from "@/lib/db/repositories/sqlite";
 import { BUDGET_CATEGORIES, DEFAULT_ALLOCATION, currentFiscalYear } from "@/lib/budget";
 
@@ -87,5 +88,39 @@ describe("invites.createProvisioned (#74 招待先の pre-provision)", () => {
     await expect(
       sqliteRepos.invites.createProvisioned({ ...base, role: "admin" }),
     ).rejects.toThrow("ROLE_CONFLICT");
+  });
+
+  it("uses createdBy municipality for new invited users and member budgets", async () => {
+    const otherMuni = "muni_invite74_other";
+    const otherAdmin = "adm_invite74_other";
+    const email = "othermuni-member74@example.jp";
+
+    run("INSERT INTO municipalities (id,name,prefecture,annual_budget) VALUES (?,?,?,?)", [
+      otherMuni,
+      "Other Invite City",
+      "Other Prefecture",
+      1000000,
+    ]);
+    run(
+      "INSERT INTO users (id,municipality_id,organization_type,role,name,email,status) VALUES (?,?,?,?,?,?,?)",
+      [otherAdmin, otherMuni, "municipality", "admin", "Other Invite Admin", "other-invite-admin@example.jp", "active"]
+    );
+
+    await sqliteRepos.invites.createProvisioned({
+      email,
+      name: "Other Muni Member",
+      role: "member",
+      municipalityName: "Other Invite City",
+      createdBy: otherAdmin,
+    });
+
+    const created = get<{ id: string; municipality_id: string }>("SELECT id, municipality_id FROM users WHERE email=?", [email]);
+    expect(created?.municipality_id).toBe(otherMuni);
+
+    const budgets = get<{ c: number }>(
+      "SELECT COUNT(*) c FROM budget_allocations WHERE user_id=? AND municipality_id=? AND fiscal_year=?",
+      [created?.id, otherMuni, currentFiscalYear()]
+    );
+    expect(budgets?.c).toBe(BUDGET_CATEGORIES.length);
   });
 });

--- a/src/app/api/admin/invites/provision.test.ts
+++ b/src/app/api/admin/invites/provision.test.ts
@@ -60,7 +60,7 @@ describe("invites.createProvisioned (#74 招待先の pre-provision)", () => {
     }
   });
 
-  it("同じ email で2回招待しても users 行は重複しない(冪等)", async () => {
+  it("同じ email・同ロールで2回招待しても users 行は重複しない(冪等)", async () => {
     const args = {
       email: "dup74@example.jp",
       name: "招待 重複三郎",
@@ -74,5 +74,18 @@ describe("invites.createProvisioned (#74 招待先の pre-provision)", () => {
     const members = await sqliteRepos.members.list();
     const matches = members.filter((m) => m.name === "招待 重複三郎");
     expect(matches.length).toBe(1);
+  });
+
+  it("同じ email を別ロールで再招待すると ROLE_CONFLICT で弾く(権限取り違え防止)", async () => {
+    const base = {
+      email: "conflict74@example.jp",
+      name: "招待 競合四郎",
+      municipalityName: "新温泉町",
+      createdBy: ADMIN_ID,
+    };
+    await sqliteRepos.invites.createProvisioned({ ...base, role: "member" });
+    await expect(
+      sqliteRepos.invites.createProvisioned({ ...base, role: "admin" }),
+    ).rejects.toThrow("ROLE_CONFLICT");
   });
 });

--- a/src/app/api/admin/invites/route.ts
+++ b/src/app/api/admin/invites/route.ts
@@ -21,7 +21,9 @@ export async function POST(req: Request) {
   if (sess instanceof Response) return sess;
 
   const { email, name, role = "member", municipalityName = "" } = await readJson<CreateBody>(req);
-  const cleanEmail = email?.trim();
+  // Supabase Auth は email を小文字化して保持し、/api/auth/me は完全一致で紐づける。
+  // pre-provision する users.email も小文字に正規化しないと大文字を含む招待で 403 が再発する(#74)。
+  const cleanEmail = email?.trim().toLowerCase();
   const cleanName = name?.trim();
 
   // pre-provision には email と氏名が必須(email が無いと /api/auth/me で紐づけられず 403 になる)。
@@ -39,7 +41,11 @@ export async function POST(req: Request) {
       municipalityName,
       createdBy: sess.userId,
     }));
-  } catch {
+  } catch (e) {
+    // 同じ email が別ロールで登録済み → サイレントに権限を取り違えないよう明示エラー。
+    if (e instanceof Error && e.message === "ROLE_CONFLICT") {
+      return bad("このメールアドレスは既に別の権限で登録されています", 409);
+    }
     return bad("DB error", 500);
   }
 

--- a/src/app/api/admin/invites/route.ts
+++ b/src/app/api/admin/invites/route.ts
@@ -7,22 +7,34 @@ export const dynamic = "force-dynamic";
 
 type CreateBody = {
   email?: string;
+  name?: string;
   role?: string;
   municipalityName?: string;
 };
 
-/** POST /api/admin/invites — 招待トークン発行 */
+// 招待で発行してよいロール。users.role に書き込むため super 等への昇格を防ぐ(#74)。
+const INVITABLE_ROLES = ["member", "manager", "admin"];
+
+/** POST /api/admin/invites — 招待トークン発行(招待先 users 行を pre-provision) */
 export async function POST(req: Request) {
   const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
 
-  const { email, role = "member", municipalityName = "" } = await readJson<CreateBody>(req);
+  const { email, name, role = "member", municipalityName = "" } = await readJson<CreateBody>(req);
+  const cleanEmail = email?.trim();
+  const cleanName = name?.trim();
+
+  // pre-provision には email と氏名が必須(email が無いと /api/auth/me で紐づけられず 403 になる)。
+  if (!cleanEmail) return bad("メールアドレスは必須です", 400);
+  if (!cleanName) return bad("お名前は必須です", 400);
+  if (!INVITABLE_ROLES.includes(role)) return bad("不正なロールです", 400);
 
   let token: string;
   let expiresAt: string;
   try {
-    ({ token, expiresAt } = await getRepos().invites.create({
-      email: email?.trim() || null,
+    ({ token, expiresAt } = await getRepos().invites.createProvisioned({
+      email: cleanEmail,
+      name: cleanName,
       role,
       municipalityName,
       createdBy: sess.userId,

--- a/src/app/api/budgets/budgets.test.ts
+++ b/src/app/api/budgets/budgets.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+import {
+  ANNUAL_BUDGET_TOTAL,
+  BUDGET_CATEGORIES,
+  DEFAULT_ALLOCATION,
+  currentFiscalYear,
+  defaultAllocationList,
+} from "@/lib/budget";
+
+// 予算枠配分の回帰テスト。
+// - 既定配分(defaultAllocationList)が年間総額に一致すること。
+// - 新規隊員を作成すると seedDefaultBudget により当年度の予算枠が
+//   既定配分どおりに自動投入されること。
+
+describe("予算 既定配分 (budget.ts)", () => {
+  it("既定配分の合計が年間総額(2,000,000)に一致する", () => {
+    const total = defaultAllocationList().reduce((s, a) => s + a.amountLimit, 0);
+    expect(ANNUAL_BUDGET_TOTAL).toBe(2_000_000);
+    expect(total).toBe(ANNUAL_BUDGET_TOTAL);
+  });
+
+  it("既定配分は全費目を網羅する", () => {
+    const cats = defaultAllocationList().map((a) => a.category);
+    expect(cats).toEqual([...BUDGET_CATEGORIES]);
+    for (const c of BUDGET_CATEGORIES) {
+      expect(DEFAULT_ALLOCATION[c]).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe("seedDefaultBudget (新規隊員作成時の予算枠自動投入)", () => {
+  it("members.upsert で作成した隊員に当年度の既定予算枠が入る", async () => {
+    const created = await sqliteRepos.members.upsert({
+      name: "予算 検証太郎",
+      role: "member",
+    });
+    expect(created.id).toBeTruthy();
+
+    const fy = currentFiscalYear();
+    const lines = await sqliteRepos.budgets.summaryByUser(created.id, fy);
+
+    // 費目ごとに既定配分の上限額が設定され、未使用(remaining=上限)であること。
+    for (const cat of BUDGET_CATEGORIES) {
+      const line = lines.find((l) => l.category === cat);
+      expect(line, `費目 ${cat} の予算行が無い`).toBeTruthy();
+      expect(line!.amountLimit).toBe(DEFAULT_ALLOCATION[cat] ?? 0);
+      expect(line!.used).toBe(0);
+      expect(line!.remaining).toBe(line!.amountLimit);
+    }
+
+    const total = lines.reduce((s, l) => s + l.amountLimit, 0);
+    expect(total).toBe(ANNUAL_BUDGET_TOTAL);
+  });
+});

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -576,8 +576,14 @@ export const sqliteRepos: Repos = {
     },
     async createProvisioned({ email, name, role, municipalityName, createdBy }) {
       // email に対応する users 行が無ければ先に作る(/api/auth/me が email で紐づけられるように)。
-      const existing = get<{ id: string }>("SELECT id FROM users WHERE email=?", [email]);
-      if (!existing) {
+      const existing = get<{ id: string; role: string }>("SELECT id, role FROM users WHERE email=?", [email]);
+      if (existing) {
+        // 別ロールでの再招待はサイレントに権限を取り違える。明示的に弾く。
+        if (existing.role !== role) throw new Error("ROLE_CONFLICT");
+        // 同ロールの再招待は冪等。退職などで無効化されていれば再有効化する。
+        run("UPDATE users SET status='active' WHERE id=?", [existing.id]);
+        if (role === "member") seedDefaultBudget(existing.id);
+      } else {
         const id = genId(role === "member" ? "m" : "s");
         const orgType = role === "member" ? "member" : "municipality";
         run(

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -574,6 +574,20 @@ export const sqliteRepos: Repos = {
       );
       return { token, expiresAt };
     },
+    async createProvisioned({ email, name, role, municipalityName, createdBy }) {
+      // email に対応する users 行が無ければ先に作る(/api/auth/me が email で紐づけられるように)。
+      const existing = get<{ id: string }>("SELECT id FROM users WHERE email=?", [email]);
+      if (!existing) {
+        const id = genId(role === "member" ? "m" : "s");
+        const orgType = role === "member" ? "member" : "municipality";
+        run(
+          "INSERT INTO users (id,municipality_id,organization_type,role,name,email,status) VALUES (?,?,?,?,?,?,?)",
+          [id, MUNI, orgType, role, name, email, "active"]
+        );
+        if (role === "member") seedDefaultBudget(id);
+      }
+      return sqliteRepos.invites.create({ email, role, municipalityName, createdBy });
+    },
     async findByToken(token) {
       const r = get<{
         token: string;

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -69,13 +69,19 @@ function fyRange(fy: string): [string, string] {
 }
 
 // 新規隊員に当年度の費目別予算枠(既定配分)を投入(既存があればスキップ)。
-function seedDefaultBudget(userId: string) {
+function municipalityOfUser(userId: string): string {
+  const row = get<{ municipality_id: string | null }>("SELECT municipality_id FROM users WHERE id=?", [userId]);
+  if (!row?.municipality_id) throw new Error("CREATOR_NOT_FOUND");
+  return row.municipality_id;
+}
+
+function seedDefaultBudget(userId: string, municipalityId = MUNI) {
   const fy = currentFiscalYear();
   for (const category of BUDGET_CATEGORIES) {
     const exists = get("SELECT id FROM budget_allocations WHERE user_id=? AND fiscal_year=? AND category=?", [userId, fy, category]);
     if (exists) continue;
     run("INSERT INTO budget_allocations (id,municipality_id,user_id,fiscal_year,category,amount_limit) VALUES (?,?,?,?,?,?)", [
-      genId("bud"), MUNI, userId, fy, category, DEFAULT_ALLOCATION[category] ?? 0,
+      genId("bud"), municipalityId, userId, fy, category, DEFAULT_ALLOCATION[category] ?? 0,
     ]);
   }
 }
@@ -576,21 +582,22 @@ export const sqliteRepos: Repos = {
     },
     async createProvisioned({ email, name, role, municipalityName, createdBy }) {
       // email に対応する users 行が無ければ先に作る(/api/auth/me が email で紐づけられるように)。
-      const existing = get<{ id: string; role: string }>("SELECT id, role FROM users WHERE email=?", [email]);
+      const existing = get<{ id: string; role: string; municipality_id: string | null }>("SELECT id, role, municipality_id FROM users WHERE email=?", [email]);
       if (existing) {
         // 別ロールでの再招待はサイレントに権限を取り違える。明示的に弾く。
         if (existing.role !== role) throw new Error("ROLE_CONFLICT");
         // 同ロールの再招待は冪等。退職などで無効化されていれば再有効化する。
         run("UPDATE users SET status='active' WHERE id=?", [existing.id]);
-        if (role === "member") seedDefaultBudget(existing.id);
+        if (role === "member") seedDefaultBudget(existing.id, existing.municipality_id ?? municipalityOfUser(createdBy));
       } else {
+        const creatorMuni = municipalityOfUser(createdBy);
         const id = genId(role === "member" ? "m" : "s");
         const orgType = role === "member" ? "member" : "municipality";
         run(
           "INSERT INTO users (id,municipality_id,organization_type,role,name,email,status) VALUES (?,?,?,?,?,?,?)",
-          [id, MUNI, orgType, role, name, email, "active"]
+          [id, creatorMuni, orgType, role, name, email, "active"]
         );
-        if (role === "member") seedDefaultBudget(id);
+        if (role === "member") seedDefaultBudget(id, creatorMuni);
       }
       return sqliteRepos.invites.create({ email, role, municipalityName, createdBy });
     },

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -771,18 +771,32 @@ export const supabaseRepos: Repos = {
     },
     async createProvisioned({ email, name, role, municipalityName, createdBy }) {
       // email に対応する users 行が無ければ先に作る(/api/auth/me が email で紐づけられるように)。
-      const { data: existing } = await supabase()
+      const { data: existing, error: selErr } = await supabase()
         .from("users")
-        .select("id")
+        .select("id, role")
         .eq("email", email)
         .maybeSingle();
-      if (!existing) {
+      if (selErr) throw selErr;
+      if (existing) {
+        // 別ロールでの再招待はサイレントに権限を取り違える。明示的に弾く。
+        if ((existing.role as string) !== role) throw new Error("ROLE_CONFLICT");
+        // 同ロールの再招待は冪等。無効化されていれば再有効化する。
+        const { error: upErr } = await supabase()
+          .from("users")
+          .update({ status: "active" })
+          .eq("id", existing.id);
+        if (upErr) throw upErr;
+        if (role === "member") await seedDefaultBudgetSb(existing.id as string);
+      } else {
         const orgType = role === "member" ? "member" : "municipality";
-        const { data: created } = await supabase()
+        // insert の失敗(RLS/一意制約等)を握り潰すと users 行が無いままトークンだけ発行され
+        // 招待先が後で 403 になる。エラーは投げてルートで 500 にする。
+        const { data: created, error: insErr } = await supabase()
           .from("users")
           .insert({ municipality_id: MUNI, organization_type: orgType, role, name, email, status: "active" })
           .select("id")
           .single();
+        if (insErr) throw insErr;
         if (role === "member" && created?.id) await seedDefaultBudgetSb(created.id);
       }
       return supabaseRepos.invites.create({ email, role, municipalityName, createdBy });

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -769,6 +769,24 @@ export const supabaseRepos: Repos = {
       });
       return { token, expiresAt };
     },
+    async createProvisioned({ email, name, role, municipalityName, createdBy }) {
+      // email に対応する users 行が無ければ先に作る(/api/auth/me が email で紐づけられるように)。
+      const { data: existing } = await supabase()
+        .from("users")
+        .select("id")
+        .eq("email", email)
+        .maybeSingle();
+      if (!existing) {
+        const orgType = role === "member" ? "member" : "municipality";
+        const { data: created } = await supabase()
+          .from("users")
+          .insert({ municipality_id: MUNI, organization_type: orgType, role, name, email, status: "active" })
+          .select("id")
+          .single();
+        if (role === "member" && created?.id) await seedDefaultBudgetSb(created.id);
+      }
+      return supabaseRepos.invites.create({ email, role, municipalityName, createdBy });
+    },
     async findByToken(token) {
       const { data } = await supabase()
         .from("invite_tokens")

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -125,13 +125,13 @@ function fyRange(fy: string): [string, string] {
 }
 
 // 新規隊員に当年度の費目別予算枠(既定配分)を投入(重複は無視)。
-async function seedDefaultBudgetSb(userId: string) {
+async function seedDefaultBudgetSb(userId: string, municipalityId = MUNI) {
   const fy = currentFiscalYear();
   await supabase()
     .from("budget_allocations")
     .upsert(
       BUDGET_CATEGORIES.map((category) => ({
-        municipality_id: MUNI,
+        municipality_id: municipalityId,
         user_id: userId,
         fiscal_year: fy,
         category,
@@ -139,6 +139,18 @@ async function seedDefaultBudgetSb(userId: string) {
       })),
       { onConflict: "user_id,fiscal_year,category", ignoreDuplicates: true }
     );
+}
+
+async function municipalityOfUserSb(userId: string): Promise<string> {
+  const { data, error } = await supabase()
+    .from("users")
+    .select("municipality_id")
+    .eq("id", userId)
+    .maybeSingle();
+  if (error) throw error;
+  const municipalityId = data?.municipality_id as string | null | undefined;
+  if (!municipalityId) throw new Error("CREATOR_NOT_FOUND");
+  return municipalityId;
 }
 
 function supabase() {
@@ -773,7 +785,7 @@ export const supabaseRepos: Repos = {
       // email に対応する users 行が無ければ先に作る(/api/auth/me が email で紐づけられるように)。
       const { data: existing, error: selErr } = await supabase()
         .from("users")
-        .select("id, role")
+        .select("id, role, municipality_id")
         .eq("email", email)
         .maybeSingle();
       if (selErr) throw selErr;
@@ -786,18 +798,22 @@ export const supabaseRepos: Repos = {
           .update({ status: "active" })
           .eq("id", existing.id);
         if (upErr) throw upErr;
-        if (role === "member") await seedDefaultBudgetSb(existing.id as string);
+        if (role === "member") {
+          const municipalityId = (existing.municipality_id as string | null) ?? await municipalityOfUserSb(createdBy);
+          await seedDefaultBudgetSb(existing.id as string, municipalityId);
+        }
       } else {
+        const creatorMuni = await municipalityOfUserSb(createdBy);
         const orgType = role === "member" ? "member" : "municipality";
         // insert の失敗(RLS/一意制約等)を握り潰すと users 行が無いままトークンだけ発行され
         // 招待先が後で 403 になる。エラーは投げてルートで 500 にする。
         const { data: created, error: insErr } = await supabase()
           .from("users")
-          .insert({ municipality_id: MUNI, organization_type: orgType, role, name, email, status: "active" })
+          .insert({ municipality_id: creatorMuni, organization_type: orgType, role, name, email, status: "active" })
           .select("id")
           .single();
         if (insErr) throw insErr;
-        if (role === "member" && created?.id) await seedDefaultBudgetSb(created.id);
+        if (role === "member" && created?.id) await seedDefaultBudgetSb(created.id, creatorMuni);
       }
       return supabaseRepos.invites.create({ email, role, municipalityName, createdBy });
     },

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -218,6 +218,12 @@ export interface Repos {
   invites: {
     /** トークンと 7 日有効期限を採番して発行する */
     create(i: { email: string | null; role: string; municipalityName: string; createdBy: string }): Promise<{ token: string; expiresAt: string }>;
+    /**
+     * 招待先の users 行を事前作成(email で冪等)してからトークンを発行する。
+     * /api/auth/me は email で auth_id を紐づけるだけ(#64)なので、先に行が無いと
+     * 招待されても 403 になる(#74)。super.createAdminInvite と同じ pre-provision 方式。
+     */
+    createProvisioned(i: { email: string; name: string; role: string; municipalityName: string; createdBy: string }): Promise<{ token: string; expiresAt: string }>;
     findByToken(token: string): Promise<InviteRow | null>;
     /** used_at が未設定のときだけ使用済みにする */
     markUsed(token: string): Promise<void>;


### PR DESCRIPTION
## 概要
Issue #74「管理者を招待のリンクが無効になる」の**根本修正**。

招待リンク自体は正常。問題は招待後に `/api/auth/me` が **email で既存 `users` 行に紐づけるだけ**(#64 で自動作成廃止)のため、行が無い **admin/manager 招待は常に 403** になっていたこと。`super.createAdminInvite` には既に「先に users 行を作る」pre-provision 方式があり、**同じ方式を admin ダッシュボードの招待にも適用**する。

## 設計(止揚: 既存 super の pre-provision パターンに統一)
アカウント作成の責務を招待ルートにも `/api/auth/me` にも分散させず、**リポジトリの 1 メソッドに集約**。`/api/auth/me`(認証層)は **変更不要**(行さえあれば既存の email リンクで通る)。

## 変更点
- **repositories(3層・追加のみ)**: `invites.createProvisioned({email,name,role,municipalityName,createdBy})` を追加。
  - email で `users` 行を冪等 upsert(`org_type`: member→`member` / 他→`municipality`、member は既定予算枠も seed)→ 既存 `create` でトークン発行。
  - 既存メソッドは無改変。
- **`/api/admin/invites` POST**: email・氏名を必須化(無いと provision 不能)、`createProvisioned` を呼ぶ。**role を `{member,manager,admin}` に限定**(`users.role` へ書くため `super` 昇格を防止)。
- **招待タブ(`admin/_app.tsx`)**: 氏名入力を追加、メール必須化、未入力時は生成ボタン無効。
- **`/api/auth/me` は変更なし**。

## 検証
- `npm test`: **23 passed**(新規 `provision.test.ts`: admin/manager/member の行作成・予算 seed・email 冪等)。`tsc --noEmit` クリーン。
- ローカル(server + Chrome / `AUTH_PROVIDER=none DEV_USER_ROLE=admin`):
  - email/氏名欠落 → **400**、`role=super` → **400**
  - 正常な職員招待 → 200 + token、**`/api/staff` に当該 users 行が provision される**ことを確認
  - トークン検証 GET → 200(role=manager, email 固定)
  - 招待タブ UI: 氏名欄追加・メール必須・未入力で生成ボタン無効を確認

## メモ
- `super.createAdminInvite`(運営者側・範囲外)には同等ロジックが重複。将来 `createProvisioned` への一本化が望ましい(本 PR では範囲外のため未統合)。
- 関連: 回帰テストのみの PR #93 は旧 develop ベース。develop が force-push で分岐したため、#93 はリベースが必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)