### PR TITLE
test: vitest が他worktreeを拾わないよう除外（npm test汚染の修正）

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 // ユニットテスト基盤。
@@ -19,5 +19,8 @@ export default defineConfig({
     },
     // node:sqlite 等の重い初期化を考慮し直列実行(共有DBファイルの競合回避)。
     fileParallelism: false,
+    // .claude/worktrees 配下は他セッションの作業ツリー。リポジトリ内に存在するため
+    // 既定の glob が拾ってしまう → 除外する。e2e(別ツール)も対象外にする。
+    exclude: [...configDefaults.exclude, ".claude/worktrees/**", "**/e2e/**"],
   },
 });


### PR DESCRIPTION
## 問題
`.claude/worktrees/` がリポジトリ内にあるため、main/develop で `npm test` すると他セッションの worktree 内テスト（と Playwright e2e spec）まで実行され、`member-smoke.spec.ts` で失敗していた。

## 修正
`configDefaults.exclude` に `.claude/worktrees/**` と `**/e2e/**` を追加。

## 効果
develop 自身のテストのみ対象に → **7ファイル/24件 green**（汚染解消）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)