### PR TITLE
fix(db): expenses の receipt_path を receipt_key にリネーム (#110)

### DIFF
--- a/supabase/migrations/20260701_025_expenses_receipt_key.sql
+++ b/supabase/migrations/20260701_025_expenses_receipt_key.sql
@@ -1,0 +1,22 @@
+-- #110: expenses の領収書キー列名をコード(receipt_key)に統一する。
+-- 経緯: 本番 Postgres は 004_expenses で receipt_path を作成したが、
+-- repo / sqlite / mapper / DTO はすべて receipt_key を読み書きしており、
+-- 本番では receipt_key 列が無く経費作成(insert)が列不一致で失敗していた。
+-- 既存の receipt_path をリネームして統一する(冪等)。
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'expenses' AND column_name = 'receipt_path'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'expenses' AND column_name = 'receipt_key'
+  ) THEN
+    ALTER TABLE public.expenses RENAME COLUMN receipt_path TO receipt_key;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'expenses' AND column_name = 'receipt_key'
+  ) THEN
+    ALTER TABLE public.expenses ADD COLUMN receipt_key text;
+  END IF;
+END $$;


### PR DESCRIPTION
## 概要
Issue #110。本番 `expenses` には `receipt_path` 列しか無いが、repo / sqlite / mapper / DTO は一貫して `receipt_key` を読み書きしており、本番で経費作成(insert)が列不一致で失敗していた。

## 修正
- `supabase/migrations/20260701_025_expenses_receipt_key.sql`:`receipt_path` → `receipt_key` にリネーム(冪等。列が無ければ追加)。
- コード変更なし(コード側は既に receipt_key で統一済み)。`receipt_path` の参照は当該マイグレーションファイル以外に存在しないことを確認済み。

## 適用について
- **本番への適用は未実施**(auto-mode のガードで本番スキーマ変更は要承認のため)。
- デプロイのマイグレーション手順で適用するか、レビュー後に手動適用してください(本番 `expenses` は0件のためリネームは安全)。
- 補足: デプロイ済みコードは既に `receipt_key` を書くため、列追加だけで現行デプロイのまま経費作成が通るようになります(ただし活動/経費の保存全体には #82/#86 のテナント修正 PR #96 のデプロイも必要)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)