### PR TITLE
release: member保存バグ修正(#82/#86)/manager改善2件/テスト基盤修正 を本番へ

### DIFF
--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -5,7 +5,10 @@ import { requireAppUser } from "@/lib/api/auth";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
+// ローカル sqlite のフォールバックは seed/sqlite の自治体 id("muni_shinonsen")に合わせる。
+// 以前は UUID 既定で、env 未設定のローカル開発だとお知らせが seed と別自治体になり空表示だった(H5)。
+// 本番(Supabase)は NEXT_PUBLIC_DEMO_MUNI_ID を設定するためこの既定は使われない。
+const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "muni_shinonsen";
 
 // お知らせ閲覧はログイン必須(隊員も自町のお知らせを読む)。未認証アクセスを遮断。
 export async function GET(req: Request) {

--- a/src/app/api/approvals/[id]/decide/__tests__/reject-reflect.test.ts
+++ b/src/app/api/approvals/[id]/decide/__tests__/reject-reflect.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+
+// 差戻し(reject)が対象(月報・経費)の status に反映されることの回帰テスト(承認連動の穴)。
+// これが無いと、承認キューから外れても月報は「提出済」、経費は元状態のまま残る。
+
+const MUNI = "muni_shinonsen";
+
+async function decideReject(id: string, comment: string) {
+  vi.resetModules();
+  vi.stubEnv("AUTH_PROVIDER", "none");
+  vi.stubEnv("DEV_USER_ROLE", "manager");
+  vi.stubEnv("DEV_USER_ID", "s1");
+  const mod = await import("../route");
+  const req = new Request("http://test/api/approvals/x/decide", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ action: "reject", comment }),
+  });
+  const res = await mod.POST(req, { params: Promise.resolve({ id }) });
+  return { status: res.status, json: await res.json() };
+}
+
+// 単段の pending 承認を作り、その id を取得する(enqueue は void のため title で引く)。
+async function enqueueSingleStep(kind: string, title: string, targetTable: string, targetId: string) {
+  await sqliteRepos.approvals.enqueue({
+    muni: MUNI,
+    kind,
+    applicantId: "m1",
+    memberName: "テスト隊員",
+    title,
+    ai: "",
+    detail: {},
+    routeName: "担当課",
+    steps: [{ approverType: "dept", approverLabel: "担当課", status: "pending" }],
+    targetTable,
+    targetId,
+  });
+  const pending = await sqliteRepos.approvals.listPending(MUNI);
+  const found = pending.find((a) => a.title === title);
+  if (!found) throw new Error("enqueue した承認が見つからない");
+  return found.id;
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("差戻しの対象反映(承認連動)", () => {
+  it("月報の差戻しで monthly_reports が rejected になる", async () => {
+    const rep = await sqliteRepos.monthlyReports.submit({ userId: "m2", ym: "2026-04", markdown: "テスト月報本文" });
+    expect(rep.status).toBe("submitted");
+
+    const apId = await enqueueSingleStep("月次報告", "差戻しテスト月報", "monthly_reports", rep.id);
+    const r = await decideReject(apId, "活動時間の内訳を追記してください");
+    expect(r.status).toBe(200);
+    expect(r.json.result).toBe("rejected");
+
+    const after = (await sqliteRepos.monthlyReports.listByUser("m2")).find((x) => x.id === rep.id);
+    expect(after?.status).toBe("rejected");
+    expect(after?.statusLabel).toContain("差戻し");
+  });
+
+  it("経費の差戻しで expenses が「差戻し」になる", async () => {
+    // 既存シード経費 e2(未精算)を対象にする。
+    const before = (await sqliteRepos.expenses.listByUser("m1")).find((x) => x.id === "e2");
+    expect(before?.status).not.toBe("差戻し");
+
+    const apId = await enqueueSingleStep("経費", "差戻しテスト経費", "expenses", "e2");
+    const r = await decideReject(apId, "領収書の添付をお願いします");
+    expect(r.status).toBe(200);
+    expect(r.json.result).toBe("rejected");
+
+    const after = (await sqliteRepos.expenses.listByUser("m1")).find((x) => x.id === "e2");
+    expect(after?.status).toBe("差戻し");
+  });
+});

--- a/src/app/api/approvals/[id]/decide/route.ts
+++ b/src/app/api/approvals/[id]/decide/route.ts
@@ -42,6 +42,13 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
     if (row.kind === "経費") await repos.expenses.update(row.target_id, { status: "承認" });
   }
 
+  // 差戻しの反映:対象を差戻し状態に戻し、隊員が修正・再提出できるようにする。
+  // これが無いと、承認キューから外れても月報/経費は提出済・承認のまま残る(承認連動の穴)。
+  if (next.status === "rejected" && row.target_id) {
+    if (row.kind === "月次報告") await repos.monthlyReports.markRejected(row.target_id);
+    if (row.kind === "経費") await repos.expenses.update(row.target_id, { status: "差戻し" });
+  }
+
   const updated = await repos.approvals.getById(id);
   return ok({ approval: updated, result: next.status });
 }

--- a/src/app/api/approvals/route.ts
+++ b/src/app/api/approvals/route.ts
@@ -5,7 +5,10 @@ import { requireAppUser } from "@/lib/api/auth";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
+// ローカル sqlite のフォールバックは seed/sqlite の自治体 id("muni_shinonsen")に合わせる。
+// 以前は UUID 既定で、env 未設定のローカル開発だと承認キューが seed と別自治体になり空表示だった(H5)。
+// 本番(Supabase)は NEXT_PUBLIC_DEMO_MUNI_ID を設定するためこの既定は使われない。
+const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "muni_shinonsen";
 
 // 進行中(pending)の承認のみ返す。完了/差戻しはキューから外れる。
 // 承認キューは役場職員(manager/admin)のみ閲覧可。未認証アクセスを遮断。

--- a/src/app/api/daily-logs/route.ts
+++ b/src/app/api/daily-logs/route.ts
@@ -6,9 +6,6 @@ import { requireAppUser } from "@/lib/api/auth";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// 単一テナント(対象自治体)の ID。デモ USER とは無関係のテナント定数。
-const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
-
 type ActivityInput = {
   type: string;
   topic: string;
@@ -81,6 +78,8 @@ export async function POST(req: Request) {
 
   // 経費明細を登録
   const memberName = (await repos.users.nameOf(userId)) ?? "隊員";
+  // 承認キューのテナントは本人の所属自治体(固定定数では本番 FK 違反になる)
+  const muni = await repos.users.municipalityOf(userId);
   // ADR-012: 隊員に割り当てられたルートを優先(委託型=団体ステップ含む)。未割当は既定。
   const assigned = await repos.routes.getForUser(userId);
   for (let i = 0; i < expenses.length; i++) {
@@ -101,7 +100,7 @@ export async function POST(req: Request) {
     const { routeName, steps } =
       assigned && assigned.steps.length ? expandAssignedRoute(assigned) : expandRoute("経費", "担当課");
     await repos.approvals.enqueue({
-      muni: MUNI,
+      muni,
       kind: "経費",
       applicantId: userId,
       memberName,

--- a/src/app/api/monthly-reports/route.ts
+++ b/src/app/api/monthly-reports/route.ts
@@ -6,7 +6,10 @@ import { requireAppUser } from "@/lib/api/auth";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
+// ローカル sqlite のフォールバックは seed/sqlite の自治体 id("muni_shinonsen")に合わせる。
+// 以前は UUID 既定で、env 未設定のローカル開発だと提出月報の承認キューが seed と別自治体になり空表示だった(H5)。
+// 本番(Supabase)は NEXT_PUBLIC_DEMO_MUNI_ID を設定するためこの既定は使われない。
+const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "muni_shinonsen";
 
 export async function GET(req: Request) {
   const sess = await requireAppUser();

--- a/src/app/member/_app.tsx
+++ b/src/app/member/_app.tsx
@@ -1482,6 +1482,7 @@ function ActivityCreateSheet({ onClose, editing, date }: { onClose: () => void; 
   const [feeling, setFeeling] = React.useState<number | null>(null);
   const [inlineExpenses, setInlineExpenses] = React.useState<InlineExpense[]>([]);
   const [saving, setSaving] = React.useState(false);
+  const [saveError, setSaveError] = React.useState<string | null>(null);
 
   function removeActivity(idx: number) {
     setActivities((cur) => cur.filter((_, i) => i !== idx));
@@ -1529,6 +1530,7 @@ function ActivityCreateSheet({ onClose, editing, date }: { onClose: () => void; 
   async function save() {
     if (!canSave) return;
     setSaving(true);
+    setSaveError(null);
     try {
       if (isEdit) {
         await updateLog(editing!.id, {
@@ -1557,7 +1559,9 @@ function ActivityCreateSheet({ onClose, editing, date }: { onClose: () => void; 
         });
         showDay(targetDate);
       }
-    } catch {
+    } catch (e) {
+      // 失敗を握り潰さず可視化(#82/#86: 押しても無反応で原因が分からない問題の対策)
+      setSaveError((e as Error)?.message || "保存に失敗しました。時間をおいて再度お試しください。");
       setSaving(false);
     }
   }
@@ -1579,6 +1583,11 @@ function ActivityCreateSheet({ onClose, editing, date }: { onClose: () => void; 
         </div>
         <div className="border-t border-slate-200 bg-white px-5 py-3">
           <div className="mx-auto max-w-2xl">
+            {saveError && (
+              <p role="alert" className="mb-2 rounded-lg bg-rose-50 px-3 py-2 text-[13px] text-rose-700">
+                保存に失敗しました: {saveError}
+              </p>
+            )}
             <button onClick={save} disabled={!canSave} className="w-full rounded-xl bg-slate-900 py-3 text-[17px] font-bold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-400">
               {saving ? "更新中…" : "更新する"}
             </button>
@@ -1733,6 +1742,11 @@ function ActivityCreateSheet({ onClose, editing, date }: { onClose: () => void; 
 
       <div className="border-t border-slate-200 bg-white px-5 py-3">
         <div className="mx-auto max-w-2xl">
+          {saveError && (
+            <p role="alert" className="mb-2 rounded-lg bg-rose-50 px-3 py-2 text-[13px] text-rose-700">
+              保存に失敗しました: {saveError}
+            </p>
+          )}
           <button onClick={save} disabled={!canSave} className="w-full rounded-xl bg-slate-900 py-3 text-[17px] font-bold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-400">
             {saving ? "記録中…" : activities.length > 0 ? `${activities.length} 件の活動を記録する` : "活動を追加してください"}
           </button>

--- a/src/lib/db/__tests__/member-save.test.ts
+++ b/src/lib/db/__tests__/member-save.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { run, get, genId } from "@/lib/db";
+import { sqliteRepos } from "@/lib/db/repositories/sqlite";
+
+// #82/#86 回帰防止:
+// 活動・日報の保存は固定の自治体定数ではなく「本人の所属自治体」で行われること。
+// 本番では users が想定と別テナント(テスト町)に属しており、固定定数だと
+// daily_logs.municipality_id_fkey に違反して保存が丸ごと失敗していた(DB 0 件)。
+// 別テナントのユーザーで作成し、書込先 municipality_id が本人由来であることを検証する。
+
+const OTHER_MUNI = "muni_other_test";
+const OTHER_USER = "u_other_test";
+
+describe("#82/#86 活動・日報の保存は本人の自治体に紐づく", () => {
+  beforeAll(() => {
+    // シード(新温泉町)とは別の自治体 + そこに属する隊員を投入
+    run("INSERT INTO municipalities (id,name,prefecture,annual_budget) VALUES (?,?,?,?)", [
+      OTHER_MUNI,
+      "別テスト町",
+      "兵庫県",
+      2000000,
+    ]);
+    run(
+      `INSERT INTO users (id,municipality_id,host_organization_id,organization_type,role,name,email,role_label,title,department,term,started_at,status)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+      [OTHER_USER, OTHER_MUNI, null, "member", "member", "別町 隊員", "other@member.example.jp", "移住促進", null, null, "1 年目", "2026-04-01", "active"]
+    );
+  });
+
+  it("dailyLogs.upsert は本人(別テスト町)の municipality_id で作成する", async () => {
+    const dl = await sqliteRepos.dailyLogs.upsert(OTHER_USER, "2026-07-01", { distanceKm: 12, feelingScore: 3 });
+    const row = get<{ municipality_id: string }>("SELECT municipality_id FROM daily_logs WHERE id=?", [dl.id]);
+    expect(row?.municipality_id).toBe(OTHER_MUNI);
+  });
+
+  it("activityLogs.create は本人の municipality_id で活動と日報を作成する", async () => {
+    const created = await sqliteRepos.activityLogs.create({
+      userId: OTHER_USER,
+      type: "移住相談",
+      topic: "空き家内覧",
+      hours: 2,
+      startTime: "09:00",
+      endTime: "11:00",
+      body: "内覧対応",
+      date: "2026-07-02",
+    });
+    const log = get<{ municipality_id: string; daily_log_id: string }>(
+      "SELECT municipality_id, daily_log_id FROM activity_logs WHERE id=?",
+      [created.id]
+    );
+    expect(log?.municipality_id).toBe(OTHER_MUNI);
+    // 自動結線された日報も本人の自治体であること
+    const dl = get<{ municipality_id: string }>("SELECT municipality_id FROM daily_logs WHERE id=?", [log!.daily_log_id]);
+    expect(dl?.municipality_id).toBe(OTHER_MUNI);
+  });
+
+  it("users.municipalityOf は本人の所属自治体を返す", async () => {
+    expect(await sqliteRepos.users.municipalityOf(OTHER_USER)).toBe(OTHER_MUNI);
+    // シードの隊員 m1 は新温泉町
+    expect(await sqliteRepos.users.municipalityOf("m1")).toBe("muni_shinonsen");
+  });
+});

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -739,6 +739,9 @@ export const sqliteRepos: Repos = {
     async markApproved(id) {
       run("UPDATE monthly_reports SET status='approved', status_label='役場承認' WHERE id=?", [id]);
     },
+    async markRejected(id) {
+      run("UPDATE monthly_reports SET status='rejected', status_label='差戻し（要修正）' WHERE id=?", [id]);
+    },
     async revertToSubmitted(userId, ym) {
       run(
         "UPDATE monthly_reports SET status='submitted', status_label='提出済(再確認待ち)' WHERE user_id=? AND year_month=? AND status='approved'",

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -33,6 +33,12 @@ import { BUDGET_CATEGORIES, DEFAULT_ALLOCATION, currentFiscalYear } from "@/lib/
 // SQLite 実装(ローカル / Vercel デモ)。SQL はここに集約し、Route からは追放する。
 const MUNI = "muni_shinonsen";
 
+// 書込時の municipality_id は固定定数ではなく本人の所属自治体から解決する。
+// (本番では users が想定と別テナントに属することがあり、固定値だと daily_logs 等で FK 違反になる)
+function muniOf(userId: string): string {
+  return get<{ municipality_id: string }>("SELECT municipality_id FROM users WHERE id=?", [userId])?.municipality_id ?? MUNI;
+}
+
 // 当月 / N ヶ月前の 'YYYY-MM' を返す(ローカル時刻基準)
 function ymOffset(offset: number): string {
   const d = new Date();
@@ -120,6 +126,9 @@ export const sqliteRepos: Repos = {
     },
     async nameOf(id) {
       return get<{ name: string }>("SELECT name FROM users WHERE id=?", [id])?.name;
+    },
+    async municipalityOf(id) {
+      return muniOf(id);
     },
     async getProfile(id) {
       const r = get<{ name: string; municipality_id: string; bio?: string; started_at?: string }>(
@@ -625,13 +634,14 @@ export const sqliteRepos: Repos = {
       const date = b.date ?? new Date().toISOString().slice(0, 10);
       const time = b.time ?? new Date().toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" });
       // ADR-021: 活動作成時に当日の daily_log を自動 upsert し daily_log_id を結線する
+      const muni = muniOf(b.userId);
       let dailyLogId = b.dailyLogId ?? null;
       if (!dailyLogId) {
         const dlId = genId("dl");
         run(
           `INSERT INTO daily_logs (id,user_id,municipality_id,log_date) VALUES (?,?,?,?)
            ON CONFLICT(user_id,log_date) DO NOTHING`,
-          [dlId, b.userId, MUNI, date]
+          [dlId, b.userId, muni, date]
         );
         const dl = get<{ id: string }>("SELECT id FROM daily_logs WHERE user_id=? AND log_date=?", [b.userId, date]);
         dailyLogId = dl?.id ?? null;
@@ -639,7 +649,7 @@ export const sqliteRepos: Repos = {
       run(
         `INSERT INTO activity_logs (id,user_id,municipality_id,daily_log_id,activity_type,topic,hours,start_time,end_time,body,log_date,log_time)
          VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
-        [id, b.userId, MUNI, dailyLogId, b.type, b.topic, b.hours, b.startTime ?? null, b.endTime ?? null, b.body, date, time]
+        [id, b.userId, muni, dailyLogId, b.type, b.topic, b.hours, b.startTime ?? null, b.endTime ?? null, b.body, date, time]
       );
       return mapLog(all("SELECT * FROM activity_logs WHERE id=?", [id])[0]);
     },
@@ -681,7 +691,7 @@ export const sqliteRepos: Repos = {
       run(
         `INSERT INTO expenses (id,user_id,municipality_id,expense_kind,category,daily_log_id,title,amount_requested,purpose,status,ai_note,citations,has_receipt,receipt_key,created_at)
          VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
-        [id, b.userId, MUNI, "single", b.category ?? "活動費", b.dailyLogId ?? null, b.title, b.amount, b.purpose, b.status ?? "申請中", "AI 判定材料は申請後に表示されます。", JSON.stringify([]), b.receiptKey ? 1 : 0, b.receiptKey ?? null, new Date().toISOString().slice(0, 10)]
+        [id, b.userId, muniOf(b.userId), "single", b.category ?? "活動費", b.dailyLogId ?? null, b.title, b.amount, b.purpose, b.status ?? "申請中", "AI 判定材料は申請後に表示されます。", JSON.stringify([]), b.receiptKey ? 1 : 0, b.receiptKey ?? null, new Date().toISOString().slice(0, 10)]
       );
       return mapExpense(all("SELECT * FROM expenses WHERE id=?", [id])[0]);
     },
@@ -693,7 +703,7 @@ export const sqliteRepos: Repos = {
             title,amount_requested,purpose,status,ai_note,citations,has_receipt,receipt_key,created_at)
          VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
         [
-          id, b.userId, MUNI, "single",
+          id, b.userId, muniOf(b.userId), "single",
           b.activityLogId, b.receiptIndex,
           b.title, b.amount, b.purpose, b.status ?? "申請中",
           "日報経由の経費(ADR-014)。AI 判定材料は申請後に表示されます。",
@@ -732,7 +742,7 @@ export const sqliteRepos: Repos = {
       run(
         `INSERT INTO monthly_reports (id,user_id,municipality_id,year_month,status,status_label,summary,plan_next)
          VALUES (?,?,?,?,?,?,?,?)`,
-        [id, b.userId, MUNI, b.ym, "submitted", "提出済", b.markdown, b.plan ?? null]
+        [id, b.userId, muniOf(b.userId), b.ym, "submitted", "提出済", b.markdown, b.plan ?? null]
       );
       return mapReport(all("SELECT * FROM monthly_reports WHERE id=?", [id])[0]);
     },
@@ -839,7 +849,7 @@ export const sqliteRepos: Repos = {
       const id = genId("dl");
       run(
         `INSERT INTO daily_logs (id,user_id,municipality_id,log_date,note,distance_km,expense_amount,feeling_score) VALUES (?,?,?,?,?,?,?,?)`,
-        [id, userId, MUNI, date, fields?.note ?? null, fields?.distanceKm ?? null, fields?.expenseAmount ?? null, fields?.feelingScore ?? null]
+        [id, userId, muniOf(userId), date, fields?.note ?? null, fields?.distanceKm ?? null, fields?.expenseAmount ?? null, fields?.feelingScore ?? null]
       );
       return mapDailyLog(all("SELECT * FROM daily_logs WHERE id=?", [id])[0]);
     },
@@ -901,7 +911,7 @@ export const sqliteRepos: Repos = {
         `INSERT INTO monthly_cycles (id,user_id,municipality_id,year_month,monthly_goal,action_plan,intake,reflection,status)
          VALUES (?,?,?,?,?,?,?,?,?)`,
         [
-          id, userId, MUNI, ym,
+          id, userId, muniOf(userId), ym,
           fields.monthlyGoal ?? null,
           JSON.stringify(fields.actionPlan ?? []),
           fields.intake ? JSON.stringify(fields.intake) : null,

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -149,6 +149,13 @@ function supabase() {
   );
 }
 
+// 書込時の municipality_id は固定定数ではなく本人の所属自治体から解決する。
+// (本番の users は MUNI 定数と別テナント=テスト町 に属しており、固定値だと daily_logs 等で FK 違反になる)
+async function muniOf(userId: string): Promise<string> {
+  const { data } = await supabase().from("users").select("municipality_id").eq("id", userId).maybeSingle();
+  return (data?.municipality_id as string) ?? MUNI;
+}
+
 // Supabase の occurred_at(timestamptz)→ log_date / log_time に変換してマッパーに渡す
 function toLogRow(r: Record<string, unknown>): Record<string, unknown> {
   const oa = r.occurred_at as string | null;
@@ -175,6 +182,9 @@ export const supabaseRepos: Repos = {
     async nameOf(id) {
       const { data } = await supabase().from("users").select("name").eq("id", id).single();
       return data?.name;
+    },
+    async municipalityOf(id) {
+      return muniOf(id);
     },
     async getProfile(id) {
       const { data } = await supabase()
@@ -836,7 +846,7 @@ export const supabaseRepos: Repos = {
         .from("activity_logs")
         .insert({
           user_id: b.userId,
-          municipality_id: MUNI,
+          municipality_id: await muniOf(b.userId),
           daily_log_id: dailyLogId,
           activity_type: b.type,
           topic: b.topic,
@@ -931,7 +941,7 @@ export const supabaseRepos: Repos = {
         .from("daily_logs")
         .insert({
           user_id: userId,
-          municipality_id: MUNI,
+          municipality_id: await muniOf(userId),
           log_date: date,
           note: fields?.note ?? null,
           distance_km: fields?.distanceKm ?? null,
@@ -967,7 +977,7 @@ export const supabaseRepos: Repos = {
         .from("expenses")
         .insert({
           user_id: b.userId,
-          municipality_id: MUNI,
+          municipality_id: await muniOf(b.userId),
           expense_kind: "single",
           category: b.category ?? "活動費",
           daily_log_id: b.dailyLogId ?? null,
@@ -989,7 +999,7 @@ export const supabaseRepos: Repos = {
         .from("expenses")
         .insert({
           user_id: b.userId,
-          municipality_id: MUNI,
+          municipality_id: await muniOf(b.userId),
           expense_kind: "single",
           source_activity_log_id: b.activityLogId,
           source_receipt_index: b.receiptIndex,
@@ -1047,7 +1057,7 @@ export const supabaseRepos: Repos = {
       }
       const { data } = await supabase()
         .from("monthly_reports")
-        .insert({ user_id: b.userId, municipality_id: MUNI, year_month: b.ym, status: "submitted", status_label: "提出済", summary: b.markdown, plan_next: b.plan ?? null })
+        .insert({ user_id: b.userId, municipality_id: await muniOf(b.userId), year_month: b.ym, status: "submitted", status_label: "提出済", summary: b.markdown, plan_next: b.plan ?? null })
         .select()
         .single();
       return mapReport(data!);
@@ -1207,7 +1217,7 @@ export const supabaseRepos: Repos = {
     async log(c) {
       await supabase().from("consultations").insert({
         user_id: c.userId,
-        municipality_id: MUNI,
+        municipality_id: await muniOf(c.userId),
         context_kind: c.contextKind,
         input_text: c.input,
         output_text: c.output,
@@ -1268,7 +1278,7 @@ export const supabaseRepos: Repos = {
       }
       const { data } = await supabase()
         .from("monthly_cycles")
-        .insert({ user_id: userId, municipality_id: MUNI, year_month: ym, ...patch })
+        .insert({ user_id: userId, municipality_id: await muniOf(userId), year_month: ym, ...patch })
         .select()
         .single();
       return mapMonthlyCycle(toCycleRow(data!));

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -1058,6 +1058,12 @@ export const supabaseRepos: Repos = {
         .update({ status: "approved", status_label: "役場承認" })
         .eq("id", id);
     },
+    async markRejected(id) {
+      await supabase()
+        .from("monthly_reports")
+        .update({ status: "rejected", status_label: "差戻し（要修正）" })
+        .eq("id", id);
+    },
     async revertToSubmitted(userId, ym) {
       await supabase()
         .from("monthly_reports")

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -162,6 +162,8 @@ export interface Repos {
   users: {
     count(): Promise<number>;
     nameOf(id: string): Promise<string | undefined>;
+    /** 書込時に使うテナント = 本人の所属自治体。固定定数では本番のテナント不一致で FK 違反になるため、必ず本人由来で解決する。 */
+    municipalityOf(id: string): Promise<string>;
     getProfile(id: string): Promise<{ name: string; municipality: string; bio?: string; assigned_at?: string } | null>;
   };
   super: {

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -276,6 +276,8 @@ export interface Repos {
     /** 隊員が月報を役場に提出(同月の下書きがあれば更新、なければ作成)。status=submitted */
     submit(b: { userId: string; ym: string; markdown: string; plan?: string }): Promise<ReportDTO>;
     markApproved(id: string): Promise<void>;
+    /** 役場が月報を差戻し → status=rejected(隊員が修正・再提出できる状態に戻す) */
+    markRejected(id: string): Promise<void>;
     /** 活動報告を編集/削除した場合、同月の承認済み月報を「提出済」に差し戻す */
     revertToSubmitted(userId: string, ym: string): Promise<void>;
   };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 // ユニットテスト基盤。
@@ -19,5 +19,8 @@ export default defineConfig({
     },
     // node:sqlite 等の重い初期化を考慮し直列実行(共有DBファイルの競合回避)。
     fileParallelism: false,
+    // .claude/worktrees 配下は他セッションの作業ツリー。リポジトリ内に存在するため
+    // 既定の glob が拾ってしまう → 除外する。e2e(別ツール)も対象外にする。
+    exclude: [...configDefaults.exclude, ".claude/worktrees/**", "**/e2e/**"],
   },
 });


### PR DESCRIPTION
## 概要
develop の取り込み済み4件を本番(main)へリリース。

## 含まれる変更
- **member**: 活動・日報が保存できない根本原因を修正（#82/#86）← 重要バグ
- **manager**: 役場API自治体IDフォールバックをseed整合 / 差戻しを対象(月報・経費)のstatusに反映
- **テスト基盤**: vitest が他worktreeを拾う問題を修正

## 検証
- develop で `npm test` 7ファイル/24件 green
- Workers Builds の fail は既存の無関係エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)