### PR TITLE
fix(manager): 月報差戻しの status を draft に(隊員画面で「承認済」誤表示の修正)

### DIFF
--- a/src/app/api/approvals/[id]/decide/__tests__/reject-reflect.test.ts
+++ b/src/app/api/approvals/[id]/decide/__tests__/reject-reflect.test.ts
@@ -45,7 +45,7 @@ async function enqueueSingleStep(kind: string, title: string, targetTable: strin
 afterEach(() => vi.unstubAllEnvs());
 
 describe("差戻しの対象反映(承認連動)", () => {
-  it("月報の差戻しで monthly_reports が rejected になる", async () => {
+  it("月報の差戻しで monthly_reports が draft(差戻し）に戻る", async () => {
     const rep = await sqliteRepos.monthlyReports.submit({ userId: "m2", ym: "2026-04", markdown: "テスト月報本文" });
     expect(rep.status).toBe("submitted");
 
@@ -54,8 +54,10 @@ describe("差戻しの対象反映(承認連動)", () => {
     expect(r.status).toBe(200);
     expect(r.json.result).toBe("rejected");
 
+    // 隊員が再提出できる編集可能状態(draft)に戻し、差戻しの意味は statusLabel が担う。
+    // 'rejected' 等の未知 status だと隊員画面が「承認済」と誤表示するため draft を採用。
     const after = (await sqliteRepos.monthlyReports.listByUser("m2")).find((x) => x.id === rep.id);
-    expect(after?.status).toBe("rejected");
+    expect(after?.status).toBe("draft");
     expect(after?.statusLabel).toContain("差戻し");
   });
 

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -750,7 +750,10 @@ export const sqliteRepos: Repos = {
       run("UPDATE monthly_reports SET status='approved', status_label='役場承認' WHERE id=?", [id]);
     },
     async markRejected(id) {
-      run("UPDATE monthly_reports SET status='rejected', status_label='差戻し（要修正）' WHERE id=?", [id]);
+      // status は 'draft' に戻す(隊員が修正・再提出できる編集可能状態)。差戻しの意味は status_label が担う。
+      // 'rejected' のような未知 status を入れると、隊員画面が status!=draft&&!=submitted を一律「承認済」と
+      // 表示してしまい、差戻しが承認済に見える(逆の意味)。隊員側 UI は draft/submitted/approved の3値のみ対応。
+      run("UPDATE monthly_reports SET status='draft', status_label='差戻し（要修正）' WHERE id=?", [id]);
     },
     async revertToSubmitted(userId, ym) {
       run(

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -1069,9 +1069,11 @@ export const supabaseRepos: Repos = {
         .eq("id", id);
     },
     async markRejected(id) {
+      // status は 'draft' に戻す(隊員が修正・再提出できる編集可能状態)。差戻しの意味は status_label が担う。
+      // 'rejected' のような未知 status だと隊員画面が一律「承認済」と表示してしまうため(逆の意味)。
       await supabase()
         .from("monthly_reports")
-        .update({ status: "rejected", status_label: "差戻し（要修正）" })
+        .update({ status: "draft", status_label: "差戻し（要修正）" })
         .eq("id", id);
     },
     async revertToSubmitted(userId, ym) {


### PR DESCRIPTION
## 概要(コードレビュー high 指摘の修正)
#98 で追加した `markRejected` が `status='rejected'` を書き込んでいたが、**隊員画面は status が `draft`/`submitted` 以外を一律「承認済」と表示**する（`member/_app.tsx:1959` の三項フォールバック）。そのため**差戻しされた月報が隊員には「承認済」（逆の意味）に見えていた**重大バグ。隊員側の status 型も `draft|submitted|approved` の3値のみで `rejected` は非対応。

## 変更
- `monthlyReports.markRejected`(sqlite/supabase): `status='rejected'` → **`'draft'`**（隊員が修正・再提出できる編集可能状態）。差戻しの意味は `status_label='差戻し（要修正）'` が担う（変更なし）。
- 役場グリッドは元々未知 status を `draft` に丸めていたため**表示不変**。
- `reject-reflect` テストの期待値を `draft` に更新（承認ワークフロー結果 `result==='rejected'` は不変）。

## 検証
- `npm test` → 24 passed ✅ / `tsc --noEmit` 通過 ✅

## 経緯
high レビューの検証フェーズがセッション上限で落ちたため、候補指摘を**手動で実コード照合し確証**（`member/_app.tsx:1958-1959`）→ 本修正。#98 は develop マージ済のため follow-up 修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)