### PR TITLE
feat: #116 全ロール共通のログアウト導線

### DIFF
--- a/src/app/admin/_app.tsx
+++ b/src/app/admin/_app.tsx
@@ -17,6 +17,7 @@ import {
   ChevronUp,
   ChevronDown,
 } from "lucide-react";
+import { LogoutButton } from "@/components/logout-button";
 import { BUDGET_CATEGORIES, ANNUAL_BUDGET_TOTAL, defaultAllocationList } from "@/lib/budget";
 
 type BudgetLine = { category: string; amountLimit: number; used: number; remaining: number };
@@ -271,7 +272,10 @@ function Header() {
       <div className="text-center text-[11px] text-slate-500">
         管理者 / 新温泉町
       </div>
-      <span className="whitespace-nowrap text-[11px] text-slate-400">v5 admin</span>
+      <div className="flex items-center gap-2">
+        <span className="whitespace-nowrap text-[11px] text-slate-400">v5 admin</span>
+        <LogoutButton />
+      </div>
     </header>
   );
 }

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -15,7 +15,7 @@ export async function GET() {
   if (process.env.AUTH_PROVIDER === "none") {
     const userId = process.env.DEV_USER_ID ?? process.env.DEMO_USER_ID ?? "m1";
     const name = (await getRepos().users.nameOf(userId)) ?? "開発ユーザー";
-    return ok({ authenticated: true, userId, name, role: process.env.DEV_USER_ROLE ?? "member" });
+    return ok({ authenticated: true, userId, name, role: process.env.DEV_USER_ROLE ?? "member", authMode: "none" });
   }
 
   const cookieStore = await cookies();
@@ -59,7 +59,7 @@ export async function GET() {
 
     if (byEmail) {
       await admin.from("users").update({ auth_id: user.id }).eq("id", byEmail.id);
-      return ok({ authenticated: true, userId: byEmail.id, name: byEmail.name, role: byEmail.role });
+      return ok({ authenticated: true, userId: byEmail.id, name: byEmail.name, role: byEmail.role, authMode: "supabase" });
     }
 
     // #64: 招待トークン経由で登録されたメアド以外は拒否(自動 member 作成しない)
@@ -69,5 +69,5 @@ export async function GET() {
     );
   }
 
-  return ok({ authenticated: true, userId: appUser.id, name: appUser.name, role: appUser.role });
+  return ok({ authenticated: true, userId: appUser.id, name: appUser.name, role: appUser.role, authMode: "supabase" });
 }

--- a/src/app/manager/_app.tsx
+++ b/src/app/manager/_app.tsx
@@ -26,6 +26,7 @@ import {
   Download,
   Loader2,
 } from "lucide-react";
+import { LogoutButton } from "@/components/logout-button";
 
 /* -------- 実データ DTO(サーバの mappers と形を一致させたクライアント側型)-------- */
 type MemberDTO = { id: string; name: string; role: string; startedAt?: string; term?: string };
@@ -546,7 +547,10 @@ function Header({ userName }: { userName?: string }) {
     <header className="flex items-center justify-between border-b border-slate-100 px-5 py-2.5">
       <span />
       <div className="text-center text-[11px] text-slate-500">{userName ?? "谷本 室長"} / 新温泉町</div>
-      <ViewerRoleSwitch />
+      <div className="flex items-center gap-2">
+        <ViewerRoleSwitch />
+        <LogoutButton />
+      </div>
     </header>
   );
 }

--- a/src/app/member/_app.tsx
+++ b/src/app/member/_app.tsx
@@ -28,6 +28,7 @@ import {
   Trash2,
   Pencil,
 } from "lucide-react";
+import { LogoutButton } from "@/components/logout-button";
 
 /* ============================================================
    v5 隊員アプリ ─ 検索エンジン型・4 機能(活動報告 / 月報 / 経費 / 事例)
@@ -563,10 +564,6 @@ export function MemberApp() {
 /* -------------------- Header / Tabs / Footer -------------------- */
 
 function Header({ onSettings, userName }: { onSettings: () => void; userName?: string | null }) {
-  async function handleLogout() {
-    await fetch("/api/auth/logout", { method: "POST" });
-    location.href = "/login";
-  }
   return (
     <header className="flex items-center justify-between border-b border-slate-100 px-5 py-2.5">
       <span />
@@ -577,11 +574,7 @@ function Header({ onSettings, userName }: { onSettings: () => void; userName?: s
         <button onClick={onSettings} className="p-1 text-slate-500 hover:text-slate-900" aria-label="設定">
           <SettingsIcon className="h-4 w-4" />
         </button>
-        <button onClick={handleLogout} className="p-1 text-slate-400 hover:text-slate-700" aria-label="ログアウト" title="ログアウト">
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-          </svg>
-        </button>
+        <LogoutButton />
       </div>
     </header>
   );

--- a/src/app/super/_app.tsx
+++ b/src/app/super/_app.tsx
@@ -8,7 +8,6 @@ import {
   Activity,
   ShieldCheck,
   Loader2,
-  LogOut,
   Plus,
   UserPlus,
   Copy,
@@ -18,6 +17,7 @@ import {
   TrendingUp,
   TrendingDown,
 } from "lucide-react";
+import { LogoutButton } from "@/components/logout-button";
 import type {
   SuperMuniDetail,
   SuperUserRow,
@@ -81,11 +81,6 @@ export function SuperApp() {
       .catch(() => setDetailErr("詳細の取得に失敗しました"));
   }
 
-  async function handleLogout() {
-    await fetch("/api/auth/logout", { method: "POST" });
-    location.href = "/login";
-  }
-
   return (
     <main className="min-h-screen bg-slate-50 text-slate-900">
       <header className="flex items-center justify-between border-b border-slate-200 bg-white px-6 py-3">
@@ -94,10 +89,7 @@ export function SuperApp() {
           <span className="text-[15px] font-bold">運営者ダッシュボード</span>
           <span className="rounded-full bg-indigo-50 px-2 py-0.5 text-[10px] font-semibold text-indigo-600">super</span>
         </div>
-        <button onClick={handleLogout} className="inline-flex items-center gap-1 text-[12px] text-slate-500 hover:text-slate-900">
-          <LogOut className="h-3.5 w-3.5" />
-          ログアウト
-        </button>
+        <LogoutButton />
       </header>
 
       {/* タブ */}

--- a/src/components/logout-button.tsx
+++ b/src/components/logout-button.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import React from "react";
+import { LogOut } from "lucide-react";
+import { apiGet } from "@/lib/api/client";
+
+type Me = { authenticated?: boolean; authMode?: string };
+
+/**
+ * 全ロール共通のログアウト導線(#116)。
+ * ヘッダー右上に常時アイコン → 確認ダイアログ → POST /api/auth/logout → /login。
+ * ローカル開発(AUTH_PROVIDER=none)は実セッションが無いため非表示にする。
+ */
+export function LogoutButton() {
+  const [visible, setVisible] = React.useState(false);
+  const [confirming, setConfirming] = React.useState(false);
+  const [busy, setBusy] = React.useState(false);
+
+  React.useEffect(() => {
+    let alive = true;
+    apiGet<Me>("/api/auth/me")
+      .then((me) => {
+        if (alive) setVisible(me?.authenticated === true && me?.authMode !== "none");
+      })
+      .catch(() => {
+        /* 未認証/取得失敗時は導線を出さない */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  async function doLogout() {
+    setBusy(true);
+    try {
+      await fetch("/api/auth/logout", { method: "POST" });
+    } catch {
+      /* 失敗してもログイン画面へ送る */
+    }
+    window.location.href = "/login";
+  }
+
+  if (!visible) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setConfirming(true)}
+        aria-label="ログアウト"
+        title="ログアウト"
+        className="p-1 text-slate-400 transition hover:text-slate-700"
+      >
+        <LogOut className="h-4 w-4" />
+      </button>
+
+      {confirming && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 px-6"
+          onClick={() => {
+            if (!busy) setConfirming(false);
+          }}
+        >
+          <div
+            className="w-full max-w-xs rounded-2xl bg-white p-6 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <p className="text-[15px] font-bold text-slate-900">ログアウトしますか?</p>
+            <p className="mt-1 text-[12px] text-slate-500">
+              再度ログインするにはメールアドレスとパスワードが必要です。
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirming(false)}
+                disabled={busy}
+                className="rounded-xl border border-slate-300 px-4 py-2 text-[13px] font-semibold text-slate-600 transition hover:bg-slate-50 disabled:opacity-60"
+              >
+                キャンセル
+              </button>
+              <button
+                type="button"
+                onClick={doLogout}
+                disabled={busy}
+                className="rounded-xl bg-slate-900 px-4 py-2 text-[13px] font-semibold text-white transition hover:bg-slate-700 disabled:opacity-60"
+              >
+                ログアウト
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## 概要
Issue #116「ログアウト導線がない」の実装。決定(全ロール共通・右上常時アイコン・確認をはさむ)に準拠。

調査の結果 **member / super には既にアドホックなログアウトが存在**(確認なし・スタイルもバラバラ)、**admin / manager には無い**ことが判明したため、共通コンポーネントに統一しました。

## 変更点
- **`src/components/logout-button.tsx`(新規・共通)**: ヘッダー右上にログアウトアイコン → **確認ダイアログ** → `POST /api/auth/logout` → `/login`。
  - `AUTH_PROVIDER=none`(ローカル開発)は実セッションが無いため**非表示**。
- **`/api/auth/me`**: クライアントが認証モードを判定できるよう `authMode`(`none`/`supabase`)を返す(**追加のみ**、既存フィールドは不変)。
- **admin / manager**: ヘッダー右上に `LogoutButton` を配置(導線を新設)。
- **member / super**: 既存のアドホックなログアウトを `LogoutButton` に置換し統一(member は設定ボタン残置、super は未使用化した `LogOut` import / `handleLogout` を削除)。

## 検証
- `tsc --noEmit` クリーン。
- ローカル(Chrome / `AUTH_PROVIDER=none`):
  - `/api/auth/me` が `authMode:"none"` を返す。
  - `none` 時はログアウトアイコンが**非表示**(全ヘッダー)。
  - (一時的に表示条件を緩めて)アイコン → **確認ダイアログ表示** → キャンセルで閉じる、を実機確認。
- 表示状態の本番フロー(`signOut`→`/login`)は `AUTH_PROVIDER=none` では非表示のため未実行。既存の member/super と同じ `POST /api/auth/logout` パターンを再利用。

## メモ
- 確認ダイアログは軽量モーダル(house style の `window.confirm` ではなく)。誤タップ防止 + 自動テスト可能。
- `src/lib/supabase/client.ts` と `src/lib/auth/client.ts` に browser client が重複(範囲外・本PRでは未統合)。

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)