### PR TITLE
fix(member): 経費/AI判定の自治体IDを本人由来に解決 (#107)

### DIFF
--- a/src/app/api/ai/expense-check/route.ts
+++ b/src/app/api/ai/expense-check/route.ts
@@ -1,18 +1,24 @@
 import { getAIProvider } from "@/lib/ai";
 import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
+import { requireAppUser } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-type Body = { title?: string; amount?: number; purpose?: string; municipalityId?: string };
+type Body = { title?: string; amount?: number; purpose?: string };
 
 export async function POST(req: Request) {
-  const { title = "", amount, purpose = "", municipalityId = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001" } = await readJson<Body>(req);
+  const sess = await requireAppUser();
+  if (sess instanceof Response) return sess;
+  const { title = "", amount, purpose = "" } = await readJson<Body>(req);
   if (!purpose.trim()) return bad("purpose が必要です");
 
+  const repos = getRepos();
+  // なりすまし防止: 自治体は body ではなくセッション本人の所属から解決する
+  const municipalityId = await repos.users.municipalityOf(sess.userId);
   // 簡易 RAG: 自治体ガイドラインを文脈に渡す(Year 2 で pgvector 化)
-  const guidelines = await getRepos().guidelines.listByMuni(municipalityId);
+  const guidelines = await repos.guidelines.listByMuni(municipalityId);
   const glText = guidelines.map((g) => `【${g.section}】${g.body}(出典: ${g.source})`).join("\n");
 
   const provider = getAIProvider();

--- a/src/app/api/expenses/route.ts
+++ b/src/app/api/expenses/route.ts
@@ -6,9 +6,6 @@ import { requireAppUser } from "@/lib/api/auth";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// 単一テナント(対象自治体)の ID。デモ USER とは無関係のテナント定数。
-const MUNI = process.env.NEXT_PUBLIC_DEMO_MUNI_ID ?? "10000000-0000-4000-8000-000000000001";
-
 export async function GET() {
   const sess = await requireAppUser();
   if (sess instanceof Response) return sess;
@@ -47,12 +44,14 @@ export async function POST(req: Request) {
 
   // 役場側の承認キューに投入(隊員申請 → 役場が見える、ADR-012)
   const memberName = (await repos.users.nameOf(userId)) ?? "隊員";
+  // 承認キューのテナントは本人の所属自治体(固定定数では本番 FK 違反になる)
+  const muni = await repos.users.municipalityOf(userId);
   // ADR-012: 隊員に割り当てられたルートを優先(委託型=団体ステップ含む)。未割当は既定。
   const assigned = await repos.routes.getForUser(userId);
   const { routeName, steps } =
     assigned && assigned.steps.length ? expandAssignedRoute(assigned) : expandRoute("経費", "担当課");
   await repos.approvals.enqueue({
-    muni: MUNI,
+    muni,
     kind: "経費",
     applicantId: userId,
     memberName,


### PR DESCRIPTION
## 概要
H5(自治体ID二重定義)の member 残存分。経費/AI判定の2ルートが固定 MUNI 定数(本番に存在しない 10000000-…)にフォールバックしており、本番で承認の FK 違反/孤立、AIガイドライン0件のリスクがあった。#82/#86(PR #96)と同型に、本人の所属自治体 `repos.users.municipalityOf(userId)` で解決する。

## 変更(2ファイル)
- `api/expenses/route.ts`: 固定 MUNI 定数を廃止し、enqueue 直前で `muni = await repos.users.municipalityOf(userId)` を解決して `approvals.enqueue({ muni })` に渡す。
- `api/ai/expense-check/route.ts`: `requireAppUser` でセッション必須化、body の `municipalityId` 受け取りを廃止(なりすまし面の解消)、本人の自治体で `guidelines.listByMuni` を引く。

## 検証
`tsc` / `npm test`(回帰含む) / `npm run build` 緑。

## 注意
スタックPR。base は `feat/member-entry-unify`(#122)。`municipalityOf` は #96 で追加済みのため本ブランチで利用可能。実装はエージェント、検証は集約担当。

🤖 Generated with [Claude Code](https://claude.com/claude-code)