### PR TITLE
fix(member): SPでカレンダーセルの情報過密・重なりを解消 (#124)

### DIFF
--- a/src/app/member/_app.tsx
+++ b/src/app/member/_app.tsx
@@ -764,10 +764,11 @@ function MonthOverview({ ym, onDayTap }: { ym: string; onDayTap: (date: string) 
                 {c.logs.length > 0 ? (
                   <>
                     <span className="absolute right-1 top-0.5 text-[12px] font-bold text-slate-500">{c.logs.length}件</span>
-                    <span className="absolute bottom-3 left-1 right-1 text-[12px] font-semibold text-slate-700">
+                    <span className="absolute bottom-3 left-1 right-1 hidden text-[12px] font-semibold text-slate-700 sm:block">
                       {c.logs.reduce((s, l) => s + l.hours, 0)}h
                     </span>
-                    {(() => { const d = monthDailyLogs.find((d) => d.date === c.date); return d?.expenseAmount ? <span className="absolute bottom-0.5 left-1 right-1 truncate text-[10px] text-slate-500">¥{Math.round(d.expenseAmount / 100) / 10}k</span> : null; })()}
+                    {(() => { const d = monthDailyLogs.find((d) => d.date === c.date); return d?.expenseAmount ? <span className="absolute bottom-0.5 left-1 right-1 hidden truncate text-[10px] text-slate-500 sm:block">¥{Math.round(d.expenseAmount / 100) / 10}k</span> : null; })()}
+                    <span className="absolute bottom-1.5 left-1/2 h-1.5 w-1.5 -translate-x-1/2 rounded-full bg-slate-400 sm:hidden" />
                   </>
                 ) : (
                   <Plus className="absolute bottom-1 right-1 h-2.5 w-2.5 text-slate-300" />


### PR DESCRIPTION
## 概要
活動カレンダーのセル(grid-cols-7 × aspect-square)が SP(≈390px=各セル約47px)で「Nh」と「¥Xk」が下段で重なり/見切れていた。推奨案A を適用。

## 変更(member/_app.tsx カレンダーセルのみ)
- 「Nh」(時間)・「¥Xk」(経費)を **base(SP)で非表示・`sm:` 以上で表示**(`hidden sm:block`)。
- 代わりに SP では「活動あり」を**セル下部中央の小ドット1つ**で表示(`sm:hidden`)。
- 日付(左上)・「N件」(右上)は対角配置で衝突しないため現状維持。

## 受け入れ
- 390px でセル内テキストの重なり/見切れ解消、sm 以上では従来通り Nh/¥Xk 表示。
- `tsc` / `npm run build` 緑。視覚確定は実機/DevTools デバイスモード推奨。

## 注意
スタックPR。base は `feat/member-entry-unify`(#122)。#107(PR #127)とは別ファイルの兄弟。実装はエージェント、検証は集約担当。

🤖 Generated with [Claude Code](https://claude.com/claude-code)