### PR TITLE
[codex] manager handoff API auth gaps

### DIFF
--- a/src/app/api/activity-logs/monthly/__tests__/authz.test.ts
+++ b/src/app/api/activity-logs/monthly/__tests__/authz.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function getMonthly(role: string, devUserId: string, qUserId: string) {
+  vi.resetModules();
+  vi.stubEnv("AUTH_PROVIDER", "none");
+  vi.stubEnv("DEV_USER_ROLE", role);
+  vi.stubEnv("DEV_USER_ID", devUserId);
+  const mod = await import("../route");
+  const res = await mod.GET(new Request(`http://test/api/activity-logs/monthly?userId=${qUserId}&ym=2026-05`));
+  return { status: res.status, json: await res.json() };
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("GET /api/activity-logs/monthly 閲覧スコープ", () => {
+  it("member は他人の月次活動ログを取得できない", async () => {
+    const r = await getMonthly("member", "m2", "m1");
+    expect(r.status).toBe(403);
+  });
+
+  it("manager は対象隊員の月次活動ログを取得できる", async () => {
+    const r = await getMonthly("manager", "s1", "m1");
+    expect(r.status).toBe(200);
+    expect(Array.isArray(r.json)).toBe(true);
+    expect(r.json.length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/api/activity-logs/monthly/route.ts
+++ b/src/app/api/activity-logs/monthly/route.ts
@@ -1,4 +1,5 @@
 import { ok, bad } from "@/lib/api/http";
+import { requireAppUser } from "@/lib/api/auth";
 import { getRepos } from "@/lib/db/repositories";
 
 export const runtime = "nodejs";
@@ -9,8 +10,13 @@ const DEFAULT_USER = process.env.NEXT_PUBLIC_DEMO_MEMBER_ID ?? "a1000000-0000-40
 // 指定隊員 × 指定月の活動ログを返す(expense_amount 込み)。
 // listForAI は AI 入力用に整形済みかつ expense_amount を持つため、役場の月報詳細表示でも流用する。
 export async function GET(req: Request) {
+  const sess = await requireAppUser();
+  if (sess instanceof Response) return sess;
   const sp = new URL(req.url).searchParams;
-  const userId = sp.get("userId") ?? DEFAULT_USER;
+  const userId = sp.get("userId") ?? sess.userId ?? DEFAULT_USER;
+  if (userId !== sess.userId && sess.role !== "manager" && sess.role !== "admin" && sess.role !== "super") {
+    return bad("権限がありません", 403);
+  }
   const ym = sp.get("ym");
   if (!ym) return bad("ym(YYYY-MM)が必要です");
   return ok(await getRepos().activityLogs.listForAI(userId, ym));

--- a/src/app/api/ai/monthly-report/__tests__/authz.test.ts
+++ b/src/app/api/ai/monthly-report/__tests__/authz.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function postMonthlyReport(role: string, devUserId: string, body: unknown) {
+  vi.resetModules();
+  vi.stubEnv("AUTH_PROVIDER", "none");
+  vi.stubEnv("DEV_USER_ROLE", role);
+  vi.stubEnv("DEV_USER_ID", devUserId);
+  vi.stubEnv("AI_PROVIDER", "mock");
+  const mod = await import("../route");
+  const res = await mod.POST(
+    new Request("http://test/api/ai/monthly-report", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    })
+  );
+  return { status: res.status, json: await res.json() };
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("POST /api/ai/monthly-report 対象隊員スコープ", () => {
+  it("member は他人の userId を指定できない", async () => {
+    const r = await postMonthlyReport("member", "m2", { userId: "m1", ym: "2026-05" });
+    expect(r.status).toBe(403);
+  });
+
+  it("manager は userId で指定した隊員の活動ログから月報を生成できる", async () => {
+    const r = await postMonthlyReport("manager", "s1", { userId: "m1", ym: "2026-05" });
+    expect(r.status).toBe(200);
+    expect(r.json.logCount).toBeGreaterThan(0);
+    expect(r.json.provider).toBe("mock");
+    expect(r.json.markdown).toContain("## 活動サマリ");
+  });
+});

--- a/src/app/api/ai/monthly-report/route.ts
+++ b/src/app/api/ai/monthly-report/route.ts
@@ -6,14 +6,17 @@ import { requireAppUser } from "@/lib/api/auth";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-type Body = { ym?: string };
+type Body = { ym?: string; userId?: string };
 
 export async function POST(req: Request) {
   const sess = await requireAppUser();
   if (sess instanceof Response) return sess;
-  const { ym } = await readJson<Body>(req);
+  const { ym, userId: requestedUserId } = await readJson<Body>(req);
   if (!ym) return bad("ym(YYYY-MM)が必要です");
-  const userId = sess.userId;
+  const userId = requestedUserId ?? sess.userId;
+  if (userId !== sess.userId && sess.role !== "manager" && sess.role !== "admin" && sess.role !== "super") {
+    return bad("権限がありません", 403);
+  }
 
   const logs = await getRepos().activityLogs.listForAI(userId, ym);
   if (logs.length === 0) return bad("対象月の活動記録がありません", 404);

--- a/src/app/api/budgets/__tests__/get-authz.test.ts
+++ b/src/app/api/budgets/__tests__/get-authz.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function getBudget(role: string, devUserId: string, qUserId: string) {
+  vi.resetModules();
+  vi.stubEnv("AUTH_PROVIDER", "none");
+  vi.stubEnv("DEV_USER_ROLE", role);
+  vi.stubEnv("DEV_USER_ID", devUserId);
+  const mod = await import("../route");
+  const res = await mod.GET(new Request(`http://test/api/budgets?userId=${qUserId}&fiscalYear=2026`));
+  return { status: res.status, json: await res.json() };
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("GET /api/budgets 閲覧スコープ", () => {
+  it("member は他人の予算枠を取得できない", async () => {
+    const r = await getBudget("member", "m2", "m1");
+    expect(r.status).toBe(403);
+  });
+
+  it("manager は対象隊員の予算枠を取得できる", async () => {
+    const r = await getBudget("manager", "s1", "m1");
+    expect(r.status).toBe(200);
+    expect(Array.isArray(r.json)).toBe(true);
+    expect(r.json.length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/api/budgets/route.ts
+++ b/src/app/api/budgets/route.ts
@@ -6,14 +6,14 @@ import { currentFiscalYear } from "@/lib/budget";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-/** GET /api/budgets?userId=&fiscalYear= — 費目別予算枠サマリ。本人 or admin/super のみ。 */
+/** GET /api/budgets?userId=&fiscalYear= — 費目別予算枠サマリ。本人 or manager/admin/super のみ。 */
 export async function GET(req: Request) {
   const sess = await requireAppUser();
   if (sess instanceof Response) return sess;
   const url = new URL(req.url);
   const userId = url.searchParams.get("userId") ?? sess.userId;
   const fiscalYear = url.searchParams.get("fiscalYear") ?? currentFiscalYear();
-  const isPrivileged = sess.role === "admin" || sess.role === "super";
+  const isPrivileged = sess.role === "manager" || sess.role === "admin" || sess.role === "super";
   if (userId !== sess.userId && !isPrivileged) return bad("他の隊員の予算枠は閲覧できません", 403);
   return ok(await getRepos().budgets.summaryByUser(userId, fiscalYear));
 }

--- a/src/app/api/members/__tests__/get-authz.test.ts
+++ b/src/app/api/members/__tests__/get-authz.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function getMembers(role: string, devUserId: string) {
+  vi.resetModules();
+  vi.stubEnv("AUTH_PROVIDER", "none");
+  vi.stubEnv("DEV_USER_ROLE", role);
+  vi.stubEnv("DEV_USER_ID", devUserId);
+  const mod = await import("../route");
+  const res = await mod.GET();
+  return { status: res.status, json: await res.json() };
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("GET /api/members 閲覧スコープ", () => {
+  it("member はロスター一覧を取得できない", async () => {
+    const r = await getMembers("member", "m1");
+    expect(r.status).toBe(403);
+  });
+
+  it("manager はロスター一覧を取得できる", async () => {
+    const r = await getMembers("manager", "s1");
+    expect(r.status).toBe(200);
+    expect(Array.isArray(r.json)).toBe(true);
+    expect(r.json.length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,11 +1,14 @@
-import { ok, readJson } from "@/lib/api/http";
+import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
-import { requireAdmin } from "@/lib/api/auth";
+import { requireAdmin, requireAppUser } from "@/lib/api/auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
+  const sess = await requireAppUser();
+  if (sess instanceof Response) return sess;
+  if (sess.role !== "manager" && sess.role !== "admin" && sess.role !== "super") return bad("権限がありません", 403);
   return ok(await getRepos().members.list());
 }
 


### PR DESCRIPTION
﻿## Summary
- Add server-side authz to `/api/activity-logs/monthly` so members cannot fetch another user's monthly activity logs.
- Allow manager/admin/super to generate monthly reports and fetch budget summaries for a target member, while blocking member impersonation.
- Require manager/admin/super for `/api/members` roster reads.
- Add regression tests for the four API scopes.

## Context
This follows up the manager UI review handoff in PR #139. It implements the concrete API auth/functionality gaps B, C, D, and E from that document. Item A remains tracked by issue #138, and item F is deferred because it needs a separate repository/UI decision around expense aggregation.

## Validation
- `npm test -- src/app/api/activity-logs/monthly/__tests__/authz.test.ts src/app/api/ai/monthly-report/__tests__/authz.test.ts src/app/api/budgets/__tests__/get-authz.test.ts src/app/api/members/__tests__/get-authz.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`

## Notes
`npm install` was run to restore the missing local `node_modules/@aws-sdk/client-s3` package required by typecheck; package files did not change.
