### PR TITLE
[codex] Scope admin member and staff routes by tenant

### DIFF
--- a/src/app/api/members/[id]/route.ts
+++ b/src/app/api/members/[id]/route.ts
@@ -1,4 +1,4 @@
-import { ok } from "@/lib/api/http";
+import { ok, bad } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
 import { requireAdmin } from "@/lib/api/auth";
 
@@ -10,6 +10,7 @@ export async function DELETE(_req: Request, { params }: { params: Promise<{ id: 
   const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
   const { id } = await params;
-  await getRepos().members.retire(id);
+  const done = await getRepos().members.retire(id, sess.municipalityId);
+  if (!done) return bad("見つかりません", 404);
   return ok({ id, status: "retired" });
 }

--- a/src/app/api/members/__tests__/tenant-scope.test.ts
+++ b/src/app/api/members/__tests__/tenant-scope.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { get, run, genId } from "@/lib/db";
+
+// #130 regression tests: admin-scoped member routes must not cross municipality boundaries.
+const MUNI_B = "muni_test_members_b";
+let adminBId = "";
+let memberBId = "";
+
+function loadRoute() {
+  vi.resetModules();
+  return import("../route");
+}
+
+function loadIdRoute() {
+  vi.resetModules();
+  return import("../[id]/route");
+}
+
+beforeAll(() => {
+  run("INSERT INTO municipalities (id,name,prefecture,annual_budget) VALUES (?,?,?,?)", [
+    MUNI_B,
+    "Test City B",
+    "Test Prefecture",
+    1000000,
+  ]);
+  adminBId = genId("adm");
+  run(
+    "INSERT INTO users (id,municipality_id,organization_type,role,name,email,status) VALUES (?,?,?,?,?,?,?)",
+    [adminBId, MUNI_B, "municipality", "admin", "Admin B", "adminb@test.example.jp", "active"]
+  );
+  memberBId = genId("m");
+  run(
+    "INSERT INTO users (id,municipality_id,organization_type,role,name,email,role_label,term,started_at,status) VALUES (?,?,?,?,?,?,?,?,?,?)",
+    [memberBId, MUNI_B, "member", "member", "Member B", `${memberBId}@member.example.jp`, "Member", "1", "2026-04-01", "active"]
+  );
+});
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("GET /api/members tenant scope", () => {
+  it("rejects non-admin users before listing members", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "member");
+    vi.stubEnv("DEV_USER_ID", "m1");
+    const mod = await loadRoute();
+    const res = await mod.GET();
+    expect(res.status).toBe(403);
+  });
+
+  it("hides municipality B members from municipality A admin", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "admin");
+    vi.stubEnv("DEV_USER_ID", "adm1");
+    const mod = await loadRoute();
+    const res = await mod.GET();
+    expect(res.status).toBe(200);
+    const list = (await res.json()) as { id: string }[];
+    expect(list.some((m) => m.id === memberBId)).toBe(false);
+    expect(list.some((m) => m.id === "m1")).toBe(true);
+  });
+
+  it("hides municipality A members from municipality B admin", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "admin");
+    vi.stubEnv("DEV_USER_ID", adminBId);
+    const mod = await loadRoute();
+    const res = await mod.GET();
+    expect(res.status).toBe(200);
+    const list = (await res.json()) as { id: string }[];
+    expect(list.some((m) => m.id === "m1")).toBe(false);
+    expect(list.some((m) => m.id === memberBId)).toBe(true);
+  });
+
+  it("lets super users list members across municipalities", async () => {
+    const superId = genId("sup");
+    run(
+      "INSERT INTO users (id,municipality_id,organization_type,role,name,email,status) VALUES (?,?,?,?,?,?,?)",
+      [superId, MUNI_B, "municipality", "super", "Super User", "super@ops.example.jp", "active"]
+    );
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "super");
+    vi.stubEnv("DEV_USER_ID", superId);
+    const mod = await loadRoute();
+    const res = await mod.GET();
+    expect(res.status).toBe(200);
+    const list = (await res.json()) as { id: string }[];
+    expect(list.some((m) => m.id === "m1")).toBe(true);
+    expect(list.some((m) => m.id === memberBId)).toBe(true);
+  });
+});
+
+describe("POST /api/members tenant scope", () => {
+  it("creates a member in the admin user's municipality", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "admin");
+    vi.stubEnv("DEV_USER_ID", adminBId);
+    const mod = await loadRoute();
+    const res = await mod.POST(
+      new Request("http://test/api/members", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "New Member B", role: "Member", startedAt: "2026-07-01" }),
+      })
+    );
+    expect(res.status).toBe(201);
+    const created = (await res.json()) as { id: string };
+    const row = get<{ municipality_id: string }>("SELECT municipality_id FROM users WHERE id=?", [created.id]);
+    expect(row?.municipality_id).toBe(MUNI_B);
+  });
+
+  it("returns 404 when an admin updates a member in another municipality", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "admin");
+    vi.stubEnv("DEV_USER_ID", "adm1");
+    const mod = await loadRoute();
+    const res = await mod.POST(
+      new Request("http://test/api/members", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: memberBId, name: "Changed", role: "Member" }),
+      })
+    );
+    expect(res.status).toBe(404);
+    const row = get<{ name: string }>("SELECT name FROM users WHERE id=?", [memberBId]);
+    expect(row?.name).toBe("Member B");
+  });
+
+  it("returns 404 when the target id belongs to staff in the same municipality", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "admin");
+    vi.stubEnv("DEV_USER_ID", "adm1");
+    const mod = await loadRoute();
+    const res = await mod.POST(
+      new Request("http://test/api/members", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "s1", name: "Changed", role: "Member" }),
+      })
+    );
+    expect(res.status).toBe(404);
+    const row = get<{ name: string }>("SELECT name FROM users WHERE id=?", ["s1"]);
+    expect(row?.name).not.toBe("Changed");
+  });
+});
+
+describe("DELETE /api/members/[id] tenant scope", () => {
+  it("returns 404 and leaves the row active when deleting another municipality's member", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "admin");
+    vi.stubEnv("DEV_USER_ID", "adm1");
+    const mod = await loadIdRoute();
+    const res = await mod.DELETE(new Request("http://test/api/members/x", { method: "DELETE" }), {
+      params: Promise.resolve({ id: memberBId }),
+    });
+    expect(res.status).toBe(404);
+    const row = get<{ status: string }>("SELECT status FROM users WHERE id=?", [memberBId]);
+    expect(row?.status).toBe("active");
+  });
+
+  it("returns 404 when the target id is staff in the same municipality", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "admin");
+    vi.stubEnv("DEV_USER_ID", "adm1");
+    const mod = await loadIdRoute();
+    const res = await mod.DELETE(new Request("http://test/api/members/x", { method: "DELETE" }), {
+      params: Promise.resolve({ id: "s1" }),
+    });
+    expect(res.status).toBe(404);
+    const row = get<{ status: string }>("SELECT status FROM users WHERE id=?", ["s1"]);
+    expect(row?.status).toBe("active");
+  });
+});

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,4 +1,4 @@
-import { ok, readJson } from "@/lib/api/http";
+import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
 import { requireAdmin } from "@/lib/api/auth";
 
@@ -6,7 +6,10 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  return ok(await getRepos().members.list());
+  const sess = await requireAdmin();
+  if (sess instanceof Response) return sess;
+  const muniId = sess.role === "super" ? undefined : sess.municipalityId;
+  return ok(await getRepos().members.list(muniId));
 }
 
 type Body = { id?: string; name: string; role: string; startedAt?: string; term?: string; hostOrganizationId?: string | null; approvalRouteId?: string | null };
@@ -15,6 +18,11 @@ export async function POST(req: Request) {
   const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
   const b = await readJson<Body>(req);
-  const saved = await getRepos().members.upsert(b);
-  return ok(saved, b.id ? 200 : 201);
+  try {
+    const saved = await getRepos().members.upsert(b, sess.municipalityId);
+    return ok(saved, b.id ? 200 : 201);
+  } catch (e) {
+    if (e instanceof Error && e.message === "TENANT_MISMATCH") return bad("見つかりません", 404);
+    throw e;
+  }
 }

--- a/src/app/api/staff/[id]/route.ts
+++ b/src/app/api/staff/[id]/route.ts
@@ -1,4 +1,4 @@
-import { ok } from "@/lib/api/http";
+import { ok, bad } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
 import { requireAdmin } from "@/lib/api/auth";
 
@@ -9,6 +9,7 @@ export async function DELETE(_req: Request, { params }: { params: Promise<{ id: 
   const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
   const { id } = await params;
-  await getRepos().staff.remove(id);
+  const done = await getRepos().staff.remove(id, sess.municipalityId);
+  if (!done) return bad("見つかりません", 404);
   return ok({ id, deleted: true });
 }

--- a/src/app/api/staff/__tests__/tenant-scope.test.ts
+++ b/src/app/api/staff/__tests__/tenant-scope.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { get, run, genId } from "@/lib/db";
+
+// #130 regression tests: admin-scoped staff routes must not cross municipality boundaries.
+const MUNI_B = "muni_test_staff_b";
+let adminBId = "";
+let staffBId = "";
+
+function loadRoute() {
+  vi.resetModules();
+  return import("../route");
+}
+
+function loadIdRoute() {
+  vi.resetModules();
+  return import("../[id]/route");
+}
+
+beforeAll(() => {
+  run("INSERT INTO municipalities (id,name,prefecture,annual_budget) VALUES (?,?,?,?)", [
+    MUNI_B,
+    "Test Staff City B",
+    "Test Prefecture",
+    1000000,
+  ]);
+  adminBId = genId("adm");
+  run(
+    "INSERT INTO users (id,municipality_id,organization_type,role,name,email,status) VALUES (?,?,?,?,?,?,?)",
+    [adminBId, MUNI_B, "municipality", "admin", "Admin B", "adminb2@test.example.jp", "active"]
+  );
+  staffBId = genId("s");
+  run(
+    "INSERT INTO users (id,municipality_id,organization_type,role,name,email,title,department,status) VALUES (?,?,?,?,?,?,?,?,?)",
+    [staffBId, MUNI_B, "municipality", "manager", "Staff B", `${staffBId}@town.example.jp`, "Lead", "General Affairs", "active"]
+  );
+});
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("GET /api/staff tenant scope", () => {
+  it("rejects non-admin users before listing staff", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "member");
+    vi.stubEnv("DEV_USER_ID", "m1");
+    const mod = await loadRoute();
+    const res = await mod.GET();
+    expect(res.status).toBe(403);
+  });
+
+  it("hides municipality B staff from municipality A admin", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "admin");
+    vi.stubEnv("DEV_USER_ID", "adm1");
+    const mod = await loadRoute();
+    const res = await mod.GET();
+    expect(res.status).toBe(200);
+    const list = (await res.json()) as { id: string }[];
+    expect(list.some((s) => s.id === staffBId)).toBe(false);
+    expect(list.some((s) => s.id === "s1")).toBe(true);
+  });
+
+  it("hides municipality A staff from municipality B admin", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "admin");
+    vi.stubEnv("DEV_USER_ID", adminBId);
+    const mod = await loadRoute();
+    const res = await mod.GET();
+    expect(res.status).toBe(200);
+    const list = (await res.json()) as { id: string }[];
+    expect(list.some((s) => s.id === "s1")).toBe(false);
+    expect(list.some((s) => s.id === staffBId)).toBe(true);
+  });
+});
+
+describe("POST /api/staff tenant scope", () => {
+  it("creates staff in the admin user's municipality", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "admin");
+    vi.stubEnv("DEV_USER_ID", adminBId);
+    const mod = await loadRoute();
+    const res = await mod.POST(
+      new Request("http://test/api/staff", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "New Staff B", dept: "General Affairs" }),
+      })
+    );
+    expect(res.status).toBe(201);
+    const created = (await res.json()) as { id: string };
+    const row = get<{ municipality_id: string }>("SELECT municipality_id FROM users WHERE id=?", [created.id]);
+    expect(row?.municipality_id).toBe(MUNI_B);
+  });
+
+  it("returns 404 when an admin updates staff in another municipality", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "admin");
+    vi.stubEnv("DEV_USER_ID", "adm1");
+    const mod = await loadRoute();
+    const res = await mod.POST(
+      new Request("http://test/api/staff", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: staffBId, name: "Changed", dept: "General Affairs" }),
+      })
+    );
+    expect(res.status).toBe(404);
+    const row = get<{ name: string }>("SELECT name FROM users WHERE id=?", [staffBId]);
+    expect(row?.name).toBe("Staff B");
+  });
+
+  it("returns 404 when the target id belongs to a member in the same municipality", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "admin");
+    vi.stubEnv("DEV_USER_ID", "adm1");
+    const mod = await loadRoute();
+    const res = await mod.POST(
+      new Request("http://test/api/staff", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "m1", name: "Changed", dept: "General Affairs" }),
+      })
+    );
+    expect(res.status).toBe(404);
+    const row = get<{ name: string }>("SELECT name FROM users WHERE id=?", ["m1"]);
+    expect(row?.name).not.toBe("Changed");
+  });
+});
+
+describe("DELETE /api/staff/[id] tenant scope", () => {
+  it("returns 404 and leaves the row in place when deleting another municipality's staff", async () => {
+    vi.stubEnv("AUTH_PROVIDER", "none");
+    vi.stubEnv("DEV_USER_ROLE", "admin");
+    vi.stubEnv("DEV_USER_ID", "adm1");
+    const mod = await loadIdRoute();
+    const res = await mod.DELETE(new Request("http://test/api/staff/x", { method: "DELETE" }), {
+      params: Promise.resolve({ id: staffBId }),
+    });
+    expect(res.status).toBe(404);
+    const row = get<{ id: string }>("SELECT id FROM users WHERE id=?", [staffBId]);
+    expect(row?.id).toBe(staffBId);
+  });
+});

--- a/src/app/api/staff/route.ts
+++ b/src/app/api/staff/route.ts
@@ -1,4 +1,4 @@
-import { ok, readJson } from "@/lib/api/http";
+import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
 import { requireAdmin } from "@/lib/api/auth";
 
@@ -6,7 +6,10 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  return ok(await getRepos().staff.list());
+  const sess = await requireAdmin();
+  if (sess instanceof Response) return sess;
+  const muniId = sess.role === "super" ? undefined : sess.municipalityId;
+  return ok(await getRepos().staff.list(muniId));
 }
 
 type Body = { id?: string; name: string; title?: string; dept: string; email?: string };
@@ -15,6 +18,11 @@ export async function POST(req: Request) {
   const sess = await requireAdmin();
   if (sess instanceof Response) return sess;
   const b = await readJson<Body>(req);
-  const saved = await getRepos().staff.upsert(b);
-  return ok(saved, b.id ? 200 : 201);
+  try {
+    const saved = await getRepos().staff.upsert(b, sess.municipalityId);
+    return ok(saved, b.id ? 200 : 201);
+  } catch (e) {
+    if (e instanceof Error && e.message === "TENANT_MISMATCH") return bad("見つかりません", 404);
+    throw e;
+  }
 }

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,5 +1,6 @@
 import { getSessionUserId, getAppUser } from "@/lib/auth/server";
 import { bad } from "@/lib/api/http";
+import { getRepos } from "@/lib/db/repositories";
 
 // ローカル開発(docs/27: AUTH_PROVIDER=none)では Supabase を介さず固定ユーザーで動かす。
 // 本番は AUTH_PROVIDER=supabase のため、この分岐は通らず「実ユーザーのみ」になる。
@@ -16,23 +17,27 @@ export async function requireSession(): Promise<{ authId: string } | Response> {
 }
 
 /**
- * セッションから「本人の app userId・role」を解決する。
+ * セッションから「本人の app userId・role・所属自治体」を解決する。
  * - 未認証 → 401
  * - 認証済みだが users 未登録(招待されていない)→ 403
- * クライアントが送ってくる userId は信用せず、必ずこの値を使う(なりすまし防止)。
- * ローカル開発(AUTH_PROVIDER=none)では固定の開発ユーザーを返す。
+ * クライアントが送ってくる userId・municipalityId は信用せず、必ずこの値を使う(なりすまし防止)。
+ * ローカル開発(AUTH_PROVIDER=none)では固定の開発ユーザーを返す(muni は既存の
+ * users.municipalityOf() で本人由来に解決し、定数の二重管理を避ける)。
  */
-export async function requireAppUser(): Promise<{ authId: string; userId: string; role: string } | Response> {
-  if (LOCAL_DEV) return { authId: "local-dev", userId: DEV_USER_ID, role: DEV_USER_ROLE };
+export async function requireAppUser(): Promise<{ authId: string; userId: string; role: string; municipalityId: string } | Response> {
+  if (LOCAL_DEV) {
+    const municipalityId = await getRepos().users.municipalityOf(DEV_USER_ID);
+    return { authId: "local-dev", userId: DEV_USER_ID, role: DEV_USER_ROLE, municipalityId };
+  }
   const authId = await getSessionUserId();
   if (!authId) return bad("認証が必要です", 401);
   const appUser = await getAppUser(authId);
   if (!appUser) return bad("このアカウントは未登録です(管理者の招待が必要です)", 403);
-  return { authId, userId: appUser.id, role: appUser.role };
+  return { authId, userId: appUser.id, role: appUser.role, municipalityId: appUser.municipalityId };
 }
 
 /** 運営者(super)専用ルートの先頭で呼ぶ。super 以外は 403。 */
-export async function requireSuper(): Promise<{ authId: string; userId: string; role: string } | Response> {
+export async function requireSuper(): Promise<{ authId: string; userId: string; role: string; municipalityId: string } | Response> {
   const sess = await requireAppUser();
   if (sess instanceof Response) return sess;
   if (sess.role !== "super") return bad("運営者(super)権限が必要です", 403);
@@ -40,7 +45,7 @@ export async function requireSuper(): Promise<{ authId: string; userId: string; 
 }
 
 /** 管理者(admin)専用ルートの先頭で呼ぶ。admin / super 以外は 403。 */
-export async function requireAdmin(): Promise<{ authId: string; userId: string; role: string } | Response> {
+export async function requireAdmin(): Promise<{ authId: string; userId: string; role: string; municipalityId: string } | Response> {
   const sess = await requireAppUser();
   if (sess instanceof Response) return sess;
   if (sess.role !== "admin" && sess.role !== "super") return bad("管理者(admin)権限が必要です", 403);

--- a/src/lib/auth/server.ts
+++ b/src/lib/auth/server.ts
@@ -48,8 +48,8 @@ export async function getAppUserId(authId: string): Promise<string | null> {
   return data?.id ?? null;
 }
 
-/** auth.users.id から app ユーザー(id + role)を 1 クエリで引く。未登録は null */
-export async function getAppUser(authId: string): Promise<{ id: string; role: string } | null> {
+/** auth.users.id から app ユーザー(id + role + 所属自治体)を 1 クエリで引く。未登録は null */
+export async function getAppUser(authId: string): Promise<{ id: string; role: string; municipalityId: string } | null> {
   const { createClient } = await import("@supabase/supabase-js");
   const admin = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -58,10 +58,10 @@ export async function getAppUser(authId: string): Promise<{ id: string; role: st
   );
   const { data } = await admin
     .from("users")
-    .select("id, role")
+    .select("id, role, municipality_id")
     .eq("auth_id", authId)
     .single();
-  return data ? { id: data.id as string, role: data.role as string } : null;
+  return data ? { id: data.id as string, role: data.role as string, municipalityId: data.municipality_id as string } : null;
 }
 
 /** auth.users.id から users テーブルの role を引く(#64: super ガード用) */

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -384,12 +384,16 @@ export const sqliteRepos: Repos = {
   },
 
   members: {
-    async list() {
+    async list(muniId) {
+      if (muniId) {
+        return all("SELECT * FROM users WHERE role='member' AND status='active' AND municipality_id=? ORDER BY started_at", [muniId]).map(mapMember);
+      }
       return all("SELECT * FROM users WHERE role='member' AND status='active' ORDER BY started_at").map(mapMember);
     },
-    async upsert(m) {
-      const existing = m.id ? get("SELECT id FROM users WHERE id=?", [m.id]) : undefined;
+    async upsert(m, muniId) {
+      const existing = m.id ? get<{ id: string; municipality_id: string; role: string }>("SELECT id, municipality_id, role FROM users WHERE id=?", [m.id]) : undefined;
       if (existing) {
+        if (existing.municipality_id !== muniId || existing.role !== "member") throw new Error("TENANT_MISMATCH");
         run("UPDATE users SET name=?, role_label=?, started_at=?, term=?, host_organization_id=?, approval_route_id=? WHERE id=?", [
           m.name, m.role, m.startedAt ?? "未設定", m.term ?? "1 年目", m.hostOrganizationId ?? null, m.approvalRouteId ?? null, m.id,
         ]);
@@ -399,27 +403,37 @@ export const sqliteRepos: Repos = {
       run(
         `INSERT INTO users (id,municipality_id,host_organization_id,organization_type,role,name,email,role_label,term,started_at,status,approval_route_id)
          VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
-        [id, MUNI, m.hostOrganizationId ?? null, "member", "member", m.name, `${id}@member.example.jp`, m.role, m.term ?? "1 年目", m.startedAt ?? "未設定", "active", m.approvalRouteId ?? null]
+        [id, muniId, m.hostOrganizationId ?? null, "member", "member", m.name, `${id}@member.example.jp`, m.role, m.term ?? "1 年目", m.startedAt ?? "未設定", "active", m.approvalRouteId ?? null]
       );
       // 新規隊員に当年度の費目別予算枠(既定配分)を自動生成
       seedDefaultBudget(id);
       return mapMember(all("SELECT * FROM users WHERE id=?", [id])[0]);
     },
-    async retire(id) {
+    async retire(id, muniId) {
+      const existing = get<{ municipality_id: string; role: string }>("SELECT municipality_id, role FROM users WHERE id=?", [id]);
+      if (!existing || existing.municipality_id !== muniId || existing.role !== "member") return false;
       run("UPDATE users SET status='retired' WHERE id=?", [id]);
       run("DELETE FROM assignments WHERE member_id=?", [id]);
+      return true;
     },
   },
 
   staff: {
-    async list() {
+    async list(muniId) {
+      if (muniId) {
+        return all(
+          "SELECT * FROM users WHERE role='manager' AND organization_type='municipality' AND municipality_id=? ORDER BY created_at",
+          [muniId]
+        ).map(mapStaff);
+      }
       return all(
         "SELECT * FROM users WHERE role='manager' AND organization_type='municipality' ORDER BY created_at"
       ).map(mapStaff);
     },
-    async upsert(s) {
-      const existing = s.id ? get("SELECT id FROM users WHERE id=?", [s.id]) : undefined;
+    async upsert(s, muniId) {
+      const existing = s.id ? get<{ id: string; municipality_id: string; role: string; organization_type: string }>("SELECT id, municipality_id, role, organization_type FROM users WHERE id=?", [s.id]) : undefined;
       if (existing) {
+        if (existing.municipality_id !== muniId || existing.role !== "manager" || existing.organization_type !== "municipality") throw new Error("TENANT_MISMATCH");
         run("UPDATE users SET name=?, title=?, department=?, email=? WHERE id=?", [
           s.name, s.title ?? "職員", s.dept, s.email ?? "", s.id,
         ]);
@@ -429,13 +443,16 @@ export const sqliteRepos: Repos = {
       run(
         `INSERT INTO users (id,municipality_id,organization_type,role,name,email,title,department,status)
          VALUES (?,?,?,?,?,?,?,?,?)`,
-        [id, MUNI, "municipality", "manager", s.name, s.email ?? "", s.title ?? "職員", s.dept, "active"]
+        [id, muniId, "municipality", "manager", s.name, s.email ?? "", s.title ?? "職員", s.dept, "active"]
       );
       return mapStaff(all("SELECT * FROM users WHERE id=?", [id])[0]);
     },
-    async remove(id) {
+    async remove(id, muniId) {
+      const existing = get<{ municipality_id: string }>("SELECT municipality_id FROM users WHERE id=? AND role='manager' AND organization_type='municipality'", [id]);
+      if (!existing || existing.municipality_id !== muniId) return false;
       run("DELETE FROM assignments WHERE staff_id=?", [id]);
       run("DELETE FROM users WHERE id=? AND role='manager'", [id]);
+      return true;
     },
   },
 

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -484,17 +484,20 @@ export const supabaseRepos: Repos = {
   },
 
   members: {
-    async list() {
-      const { data } = await supabase()
+    async list(muniId) {
+      let q = supabase()
         .from("users")
         .select("*")
         .eq("role", "member")
-        .eq("status", "active")
-        .order("started_at");
+        .eq("status", "active");
+      if (muniId) q = q.eq("municipality_id", muniId);
+      const { data } = await q.order("started_at");
       return (data ?? []).map(mapMember);
     },
-    async upsert(m) {
+    async upsert(m, muniId) {
       if (m.id) {
+        const { data: existing } = await supabase().from("users").select("municipality_id, role").eq("id", m.id).maybeSingle();
+        if (!existing || (existing.municipality_id as string) !== muniId || existing.role !== "member") throw new Error("TENANT_MISMATCH");
         const { data } = await supabase()
           .from("users")
           .update({
@@ -509,7 +512,7 @@ export const supabaseRepos: Repos = {
       const { data } = await supabase()
         .from("users")
         .insert({
-          municipality_id: MUNI,
+          municipality_id: muniId,
           organization_type: "member",
           host_organization_id: m.hostOrganizationId ?? null,
           approval_route_id: m.approvalRouteId ?? null,
@@ -526,24 +529,30 @@ export const supabaseRepos: Repos = {
       if (data?.id) await seedDefaultBudgetSb(data.id);
       return mapMember(data!);
     },
-    async retire(id) {
+    async retire(id, muniId) {
+      const { data: existing } = await supabase().from("users").select("municipality_id, role").eq("id", id).maybeSingle();
+      if (!existing || (existing.municipality_id as string) !== muniId || existing.role !== "member") return false;
       await supabase().from("users").update({ status: "retired" }).eq("id", id);
       await supabase().from("assignments").delete().eq("member_id", id);
+      return true;
     },
   },
 
   staff: {
-    async list() {
-      const { data } = await supabase()
+    async list(muniId) {
+      let q = supabase()
         .from("users")
         .select("*")
         .eq("role", "manager")
-        .eq("organization_type", "municipality")
-        .order("created_at");
+        .eq("organization_type", "municipality");
+      if (muniId) q = q.eq("municipality_id", muniId);
+      const { data } = await q.order("created_at");
       return (data ?? []).map(mapStaff);
     },
-    async upsert(s) {
+    async upsert(s, muniId) {
       if (s.id) {
+        const { data: existing } = await supabase().from("users").select("municipality_id, role, organization_type").eq("id", s.id).maybeSingle();
+        if (!existing || (existing.municipality_id as string) !== muniId || existing.role !== "manager" || existing.organization_type !== "municipality") throw new Error("TENANT_MISMATCH");
         const { data } = await supabase()
           .from("users")
           .update({ name: s.name, title: s.title ?? "職員", department: s.dept, email: s.email ?? null })
@@ -555,7 +564,7 @@ export const supabaseRepos: Repos = {
       const { data } = await supabase()
         .from("users")
         .insert({
-          municipality_id: MUNI,
+          municipality_id: muniId,
           organization_type: "municipality",
           role: "manager",
           name: s.name,
@@ -568,9 +577,12 @@ export const supabaseRepos: Repos = {
         .single();
       return mapStaff(data!);
     },
-    async remove(id) {
+    async remove(id, muniId) {
+      const { data: existing } = await supabase().from("users").select("municipality_id").eq("id", id).eq("role", "manager").eq("organization_type", "municipality").maybeSingle();
+      if (!existing || (existing.municipality_id as string) !== muniId) return false;
       await supabase().from("assignments").delete().eq("staff_id", id);
       await supabase().from("users").delete().eq("id", id).eq("role", "manager");
+      return true;
     },
   },
 

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -188,14 +188,18 @@ export interface Repos {
     analytics(): Promise<SuperAnalytics>;
   };
   members: {
-    list(): Promise<MemberDTO[]>;
-    upsert(m: { id?: string; name: string; role: string; startedAt?: string; term?: string; hostOrganizationId?: string | null; approvalRouteId?: string | null }): Promise<MemberDTO>;
-    retire(id: string): Promise<void>;
+    /** muniId 省略 = 絞り込みなし(super 専用)。admin は必ず自分の所属を渡す。 */
+    list(muniId?: string): Promise<MemberDTO[]>;
+    upsert(m: { id?: string; name: string; role: string; startedAt?: string; term?: string; hostOrganizationId?: string | null; approvalRouteId?: string | null }, muniId: string): Promise<MemberDTO>;
+    /** 対象が muniId に属さない/存在しない場合は false(ルート層は 404 に変換) */
+    retire(id: string, muniId: string): Promise<boolean>;
   };
   staff: {
-    list(): Promise<StaffDTO[]>;
-    upsert(s: { id?: string; name: string; title?: string; dept: string; email?: string }): Promise<StaffDTO>;
-    remove(id: string): Promise<void>;
+    /** muniId 省略 = 絞り込みなし(super 専用)。admin は必ず自分の所属を渡す。 */
+    list(muniId?: string): Promise<StaffDTO[]>;
+    upsert(s: { id?: string; name: string; title?: string; dept: string; email?: string }, muniId: string): Promise<StaffDTO>;
+    /** 対象が muniId に属さない/存在しない場合は false(ルート層は 404 に変換) */
+    remove(id: string, muniId: string): Promise<boolean>;
   };
   assignments: {
     map(): Promise<Record<string, string[]>>;


### PR DESCRIPTION
﻿## Summary
- Add municipality ID to authenticated app-user context and use it in admin member/staff routes.
- Scope `/api/members` and `/api/staff` list/create/update/delete paths to the caller's municipality, while keeping super list access unscoped.
- Return 404 for cross-tenant or wrong-resource-type member/staff mutations.
- Add regression tests for unauthorized access, tenant-filtered GET, tenant-bound create/update/delete, and same-tenant role mismatch cases.

## Root Cause
Admin routes for members and staff previously used repository methods without caller municipality context. That allowed admin data paths to list or mutate records outside the caller's tenant boundary.

## Validation
- `npm test -- src/app/api/members/__tests__/tenant-scope.test.ts src/app/api/staff/__tests__/tenant-scope.test.ts` passes: 16 tests
- `npm run typecheck` passes
- `npm test` passes: 46 tests
- `npm run build` passes

## Notes
- `npm run lint` is not usable in this repo as currently configured: `next lint` is interpreted as a project directory under Next 16 and fails before linting.
- Build still emits existing Next/Turbopack warnings about workspace root inference, deprecated middleware convention, and an NFT trace warning from `src/lib/storage/local.ts` via `/api/health`; these are not introduced by this change.

Closes #130
