### PR TITLE
[codex] Audit approval decisions by user

### DIFF
--- a/src/app/api/approvals/[id]/decide/__tests__/decide-authz.test.ts
+++ b/src/app/api/approvals/[id]/decide/__tests__/decide-authz.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { get, run } from "@/lib/db";
+import type { ApprovalStep } from "@/lib/workflow";
 
-// 承認/差戻し(decide)の認可ガード回帰テスト(PR #77)。
-// 役場職員(manager/admin)以外の自己承認・無権限承認を遮断していることを保証する。
-// AUTH_PROVIDER=none + DEV_USER_ROLE 切替で各ロールになりすます(vitest.config 参照)。
+const OTHER_MUNI = "muni_decide_authz_other";
+const OTHER_MANAGER = "s_decide_other";
+const OTHER_APPROVAL = "ap_decide_other";
 
 function reqPost(body: unknown) {
   return new Request("http://test/api/approvals/x/decide", {
@@ -12,54 +14,125 @@ function reqPost(body: unknown) {
   });
 }
 
-// ロールを切り替えて route を再評価する(auth.ts は import 時に DEV_USER_ROLE を捕捉するため)。
-async function decide(role: string, id: string, body: unknown) {
+async function decide(role: string, id: string, body: unknown, userId = role === "member" ? "m1" : "s1") {
   vi.resetModules();
   vi.stubEnv("AUTH_PROVIDER", "none");
   vi.stubEnv("DEV_USER_ROLE", role);
-  vi.stubEnv("DEV_USER_ID", role === "member" ? "m1" : "s1");
+  vi.stubEnv("DEV_USER_ID", userId);
   const mod = await import("../route");
   const res = await mod.POST(reqPost(body), { params: Promise.resolve({ id }) });
   return { status: res.status, json: await res.json() };
 }
 
+beforeAll(() => {
+  run("INSERT INTO municipalities (id,name,prefecture,annual_budget) VALUES (?,?,?,?)", [
+    OTHER_MUNI,
+    "Other City",
+    "Other Prefecture",
+    1000000,
+  ]);
+  run(
+    "INSERT INTO users (id,municipality_id,organization_type,role,name,email,status) VALUES (?,?,?,?,?,?,?)",
+    [OTHER_MANAGER, OTHER_MUNI, "municipality", "manager", "Other Manager", "other-manager@example.jp", "active"]
+  );
+  run(
+    `INSERT INTO approvals (id,municipality_id,kind,applicant_id,member_name,title,ai,citations,detail,route_name,steps,current_step,status)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    [
+      OTHER_APPROVAL,
+      OTHER_MUNI,
+      "test",
+      null,
+      "Other Member",
+      "Other municipality approval",
+      "",
+      JSON.stringify([]),
+      JSON.stringify({}),
+      "Other Route",
+      JSON.stringify([{ approverType: "dept", approverLabel: "Other Dept", status: "pending" }]),
+      0,
+      "pending",
+    ]
+  );
+});
+
 afterEach(() => vi.unstubAllEnvs());
 
-describe("POST /api/approvals/[id]/decide 認可ガード(#77 回帰)", () => {
-  it("member は承認できない(自己承認・無権限承認を 403 で遮断)", async () => {
+describe("POST /api/approvals/[id]/decide authz and audit", () => {
+  it("rejects member users before reading approval rows", async () => {
     const r = await decide("member", "a1", { action: "approve" });
     expect(r.status).toBe(403);
-    expect(r.json.error).toContain("承認権限");
   });
 
-  it("member はロールゲートで弾かれ、存在しない id でも DB 参照前に 403", async () => {
+  it("rejects member users before revealing missing approval ids", async () => {
     const r = await decide("member", "no-such-id", { action: "approve" });
     expect(r.status).toBe(403);
   });
 
-  it("manager は承認できる(多段ルートは次ステップへ前進し pending 継続)", async () => {
-    // a4: 担当課 → 受入団体 → 企画課 の 3 段、current_step=0。
+  it("blocks managers from deciding approvals in another municipality", async () => {
+    const r = await decide("manager", OTHER_APPROVAL, { action: "approve" }, "s1");
+    expect(r.status).toBe(404);
+    const row = get<{ status: string; steps: string }>("SELECT status, steps FROM approvals WHERE id=?", [OTHER_APPROVAL]);
+    expect(row?.status).toBe("pending");
+    const steps = JSON.parse(row?.steps ?? "[]") as ApprovalStep[];
+    expect(steps[0]?.decidedByUserId).toBeUndefined();
+  });
+
+  it("blocks another municipality manager from deciding seed approvals", async () => {
+    const r = await decide("manager", "a1", { action: "approve" }, OTHER_MANAGER);
+    expect(r.status).toBe(404);
+  });
+
+  it("allows manager approval and records the decider on the current step", async () => {
     const r = await decide("manager", "a4", { action: "approve" });
     expect(r.status).toBe(200);
     expect(r.json.result).toBe("pending");
+    const decidedStep = r.json.approval.steps[0] as ApprovalStep;
+    expect(decidedStep.status).toBe("approved");
+    expect(decidedStep.decidedByUserId).toBe("s1");
+    expect(decidedStep.decidedByRole).toBe("manager");
   });
 
-  it("manager の最終承認で approved になり、再処理は 409", async () => {
-    // a2: 最終ステップが pending(current_step=1)。1 回承認で確定。
+  it("records top-level and step-level audit data for final approval", async () => {
     const first = await decide("manager", "a2", { action: "approve" });
     expect(first.status).toBe(200);
     expect(first.json.result).toBe("approved");
+
+    const row = get<{ status: string; decided_by: string; decided_at: string | null; comment: string | null; steps: string }>(
+      "SELECT status, decided_by, decided_at, comment, steps FROM approvals WHERE id=?",
+      ["a2"]
+    );
+    expect(row?.status).toBe("approved");
+    expect(row?.decided_by).toBe("s1");
+    expect(row?.decided_at).toBeTruthy();
+    expect(row?.comment).toBeNull();
+    const steps = JSON.parse(row?.steps ?? "[]") as ApprovalStep[];
+    expect(steps[1]?.decidedByUserId).toBe("s1");
 
     const again = await decide("manager", "a2", { action: "approve" });
     expect(again.status).toBe(409);
   });
 
-  it("manager の差戻しは理由 5 文字未満で 400、妥当な理由で rejected", async () => {
+  it("validates reject comments and records rejection audit data", async () => {
     const tooShort = await decide("manager", "a3", { action: "reject", comment: "x" });
     expect(tooShort.status).toBe(400);
 
-    const ok = await decide("manager", "a3", { action: "reject", comment: "添付不足のため差戻します" });
+    const comment = "Please attach the missing receipt";
+    const ok = await decide("manager", "a3", { action: "reject", comment });
     expect(ok.status).toBe(200);
     expect(ok.json.result).toBe("rejected");
+
+    const row = get<{ status: string; decided_by: string; decided_at: string | null; comment: string | null; steps: string }>(
+      "SELECT status, decided_by, decided_at, comment, steps FROM approvals WHERE id=?",
+      ["a3"]
+    );
+    expect(row?.status).toBe("rejected");
+    expect(row?.decided_by).toBe("s1");
+    expect(row?.decided_at).toBeTruthy();
+    expect(row?.comment).toBe(comment);
+    const steps = JSON.parse(row?.steps ?? "[]") as ApprovalStep[];
+    expect(steps[0]?.comment).toBe(comment);
+    expect(steps[0]?.decidedByUserId).toBe("s1");
+    expect(steps[0]?.decidedByRole).toBe("manager");
   });
 });

--- a/src/app/api/approvals/[id]/decide/route.ts
+++ b/src/app/api/approvals/[id]/decide/route.ts
@@ -19,6 +19,8 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
   const row = await repos.approvals.getRaw(id);
   if (!row) return bad("not found", 404);
+  const userMuni = await repos.users.municipalityOf(sess.userId);
+  if (row.municipality_id !== userMuni) return bad("not found", 404);
   if (row.status !== "pending") return bad("既に処理済みです", 409);
 
   const steps = JSON.parse(row.steps) as ApprovalStep[];
@@ -26,15 +28,18 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
   let next;
   if (b.action === "approve") {
-    next = applyApprove(steps, current);
+    next = applyApprove(steps, current, { userId: sess.userId, role: sess.role });
   } else if (b.action === "reject") {
     if (!b.comment || b.comment.trim().length < 5) return bad("差戻し理由は 5 文字以上が必要です");
-    next = applyReject(steps, current, b.comment.trim());
+    next = applyReject(steps, current, b.comment.trim(), { userId: sess.userId, role: sess.role });
   } else {
     return bad("action は approve / reject");
   }
 
-  await repos.approvals.updateState(id, next.steps, next.currentStep, next.status);
+  await repos.approvals.updateState(id, next.steps, next.currentStep, next.status, {
+    decidedBy: sess.userId,
+    comment: b.action === "reject" ? b.comment?.trim() ?? null : null,
+  });
 
   // 最終承認の反映
   if (next.status === "approved" && row.target_id) {

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -21,6 +21,9 @@ function open(): DB {
   for (const sql of [
     "ALTER TABLE expenses ADD COLUMN receipt_key TEXT",
     "ALTER TABLE municipalities ADD COLUMN settings TEXT NOT NULL DEFAULT '{}'",
+    "ALTER TABLE approvals ADD COLUMN decided_by TEXT",
+    "ALTER TABLE approvals ADD COLUMN decided_at TEXT",
+    "ALTER TABLE approvals ADD COLUMN comment TEXT",
   ]) {
     try { db.exec(sql); } catch { /* 既に存在 */ }
   }

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -788,9 +788,15 @@ export const sqliteRepos: Repos = {
       return all("SELECT * FROM approvals WHERE municipality_id=? AND status='pending' ORDER BY created_at", [muni]).map(mapApproval);
     },
     async getRaw(id) {
-      return get<ApprovalRaw>("SELECT id,kind,steps,current_step,status,target_table,target_id FROM approvals WHERE id=?", [id]);
+      return get<ApprovalRaw>("SELECT id,municipality_id,kind,steps,current_step,status,target_table,target_id FROM approvals WHERE id=?", [id]);
     },
-    async updateState(id, steps, currentStep, status) {
+    async updateState(id, steps, currentStep, status, decision) {
+      if (decision) {
+        run("UPDATE approvals SET steps=?, current_step=?, status=?, decided_by=?, decided_at=datetime('now'), comment=? WHERE id=?", [
+          JSON.stringify(steps), currentStep, status, decision.decidedBy, decision.comment ?? null, id,
+        ]);
+        return;
+      }
       run("UPDATE approvals SET steps=?, current_step=?, status=? WHERE id=?", [JSON.stringify(steps), currentStep, status, id]);
     },
     async getById(id) {

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -1126,12 +1126,13 @@ export const supabaseRepos: Repos = {
     async getRaw(id): Promise<ApprovalRaw | undefined> {
       const { data } = await supabase()
         .from("approvals")
-        .select("id, kind, steps, current_step, status, target_table, target_id")
+        .select("id, municipality_id, kind, steps, current_step, status, target_table, target_id")
         .eq("id", id)
         .single();
       if (!data) return undefined;
       return {
         id: data.id,
+        municipality_id: data.municipality_id,
         kind: data.kind,
         steps: JSON.stringify(data.steps),
         current_step: data.current_step,
@@ -1140,10 +1141,17 @@ export const supabaseRepos: Repos = {
         target_id: data.target_id ?? null,
       };
     },
-    async updateState(id, steps, currentStep, status) {
+    async updateState(id, steps, currentStep, status, decision) {
       await supabase()
         .from("approvals")
-        .update({ steps, current_step: currentStep, status })
+        .update({
+          steps,
+          current_step: currentStep,
+          status,
+          ...(decision
+            ? { approver_id: decision.decidedBy, approved_at: new Date().toISOString(), comment: decision.comment ?? null }
+            : {}),
+        })
         .eq("id", id);
     },
     async getById(id) {

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -70,6 +70,7 @@ export type LogForAI = {
 // 承認の状態遷移に必要な生フィールド
 export type ApprovalRaw = {
   id: string;
+  municipality_id: string;
   kind: string;
   steps: string; // JSON
   current_step: number;
@@ -290,7 +291,13 @@ export interface Repos {
   approvals: {
     listPending(muni: string): Promise<ApprovalDTO[]>;
     getRaw(id: string): Promise<ApprovalRaw | undefined>;
-    updateState(id: string, steps: unknown[], currentStep: number, status: string): Promise<void>;
+    updateState(
+      id: string,
+      steps: unknown[],
+      currentStep: number,
+      status: string,
+      decision?: { decidedBy: string; comment?: string | null }
+    ): Promise<void>;
     getById(id: string): Promise<ApprovalDTO | undefined>;
     enqueue(a: {
       muni: string;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -180,6 +180,9 @@ CREATE TABLE IF NOT EXISTS approvals (
   status TEXT NOT NULL DEFAULT 'pending',  -- pending | approved | rejected
   target_table TEXT,
   target_id TEXT,
+  decided_by TEXT,
+  decided_at TEXT,
+  comment TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -11,6 +11,13 @@ export type ApprovalStep = {
   status: StepStatus;
   comment?: string;
   decidedAt?: string;
+  decidedByUserId?: string;
+  decidedByRole?: string;
+};
+
+type DecisionActor = {
+  userId: string;
+  role: string;
 };
 
 // kind ごとの既定ルートを展開(隊員ごとのカスタムは Year 2)。
@@ -55,9 +62,16 @@ const today = () =>
   new Date().toLocaleDateString("ja-JP", { month: "numeric", day: "numeric" });
 
 // 承認:現ステップを approved に。次があれば pending、無ければ全体 approved。
-export function applyApprove(steps: ApprovalStep[], currentStep: number) {
+export function applyApprove(steps: ApprovalStep[], currentStep: number, actor?: DecisionActor) {
   const next = steps.map((s, i) =>
-    i === currentStep ? { ...s, status: "approved" as StepStatus, decidedAt: today() } : s
+    i === currentStep
+      ? {
+          ...s,
+          status: "approved" as StepStatus,
+          decidedAt: today(),
+          ...(actor ? { decidedByUserId: actor.userId, decidedByRole: actor.role } : {}),
+        }
+      : s
   );
   if (currentStep + 1 < next.length) {
     next[currentStep + 1] = { ...next[currentStep + 1], status: "pending" };
@@ -67,9 +81,17 @@ export function applyApprove(steps: ApprovalStep[], currentStep: number) {
 }
 
 // 差戻し:現ステップを rejected(コメント必須)→ 全体差戻し。
-export function applyReject(steps: ApprovalStep[], currentStep: number, comment: string) {
+export function applyReject(steps: ApprovalStep[], currentStep: number, comment: string, actor?: DecisionActor) {
   const next = steps.map((s, i) =>
-    i === currentStep ? { ...s, status: "rejected" as StepStatus, comment, decidedAt: today() } : s
+    i === currentStep
+      ? {
+          ...s,
+          status: "rejected" as StepStatus,
+          comment,
+          decidedAt: today(),
+          ...(actor ? { decidedByUserId: actor.userId, decidedByRole: actor.role } : {}),
+        }
+      : s
   );
   return { steps: next, currentStep, status: "rejected" as const };
 }


### PR DESCRIPTION
﻿## Summary
- Add soft decision audit metadata for approval approve/reject actions.
- Record the deciding user/role on the current approval step and persist the latest decider at the repository layer.
- Block `/api/approvals/[id]/decide` when the approval belongs to another municipality.
- Extend SQLite approvals with compatible `decided_by`, `decided_at`, and `comment` columns; Supabase reuses existing `approver_id`, `approved_at`, and `comment`.

## Root Cause
The decide route only checked the coarse session role (`manager`/`admin`). It did not tie a decision to a server-side actor record and did not verify that the approval row belonged to the caller's municipality.

## Policy
This implements the soft-recording path for #138. It does not add strict per-step assignee enforcement or remove the manager UI viewer-role switch; those remain separate design tasks.

## Validation
- `npm test -- src/app/api/approvals/[id]/decide/__tests__/decide-authz.test.ts src/app/api/approvals/[id]/decide/__tests__/reject-reflect.test.ts` passes: 9 tests
- `npm run typecheck` passes
- `npm test` passes: 35 tests
- `npm run build` passes

## Notes
- `npm install` was run to restore the missing local `node_modules/@aws-sdk/client-s3` package required by typecheck; package files did not change.
- `npm run lint` is still blocked by the existing Next 16 `next lint` script behavior: it treats `lint` as a project directory and exits before linting.
- Build still emits existing Next/Turbopack warnings about workspace root inference, deprecated middleware convention, and an NFT trace warning from `src/lib/storage/local.ts` via `/api/health`.

Closes #138
