### PR TITLE
Fix auth redirects by resolved role

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
+import { createClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
+import { homePathForRole, safeRelativePath } from "@/lib/auth/role-path";
 
 export const dynamic = "force-dynamic";
 
@@ -8,8 +10,7 @@ export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
   // open redirect 防止: next は同一オリジンの相対パスのみ許可
-  const rawNext = searchParams.get("next") ?? "/member";
-  const next = rawNext.startsWith("/") && !rawNext.startsWith("//") ? rawNext : "/member";
+  const next = safeRelativePath(searchParams.get("next"));
 
   if (!code) {
     return NextResponse.redirect(`${origin}/login?error=missing_code`);
@@ -39,5 +40,36 @@ export async function GET(request: Request) {
     return NextResponse.redirect(`${origin}/login?error=${encodeURIComponent(error.message)}`);
   }
 
-  return NextResponse.redirect(`${origin}${next}`);
+  const { data: { user } } = await supabase.auth.getUser();
+  const role = user ? await getAppUserRole(user.id, user.email) : null;
+
+  return NextResponse.redirect(`${origin}${next ?? homePathForRole(role)}`);
+}
+
+async function getAppUserRole(authId: string, email: string | null | undefined): Promise<string | null> {
+  const admin = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } }
+  );
+
+  const { data: appUser } = await admin
+    .from("users")
+    .select("id, role")
+    .eq("auth_id", authId)
+    .single();
+
+  if (appUser?.role) return appUser.role as string;
+  if (!email) return null;
+
+  const { data: byEmail } = await admin
+    .from("users")
+    .select("id, role")
+    .eq("email", email)
+    .single();
+
+  if (!byEmail) return null;
+
+  await admin.from("users").update({ auth_id: authId }).eq("id", byEmail.id);
+  return byEmail.role as string;
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,22 +2,16 @@
 
 import React from "react";
 import { createSupabaseClient } from "@/lib/auth/client";
+import { homePathForRole, safeRelativePath } from "@/lib/auth/role-path";
 import { useSearchParams, useRouter } from "next/navigation";
 import { Loader2, Mail, Lock } from "lucide-react";
 import Link from "next/link";
-
-const ROLE_PATH: Record<string, string> = {
-  super: "/super",
-  admin: "/admin",
-  manager: "/manager",
-  member: "/member",
-};
 
 function LoginForm() {
   const searchParams = useSearchParams();
   const router = useRouter();
   // ?next= が指定されていればそちら優先、なければロールで振り分け
-  const nextParam = searchParams.get("next");
+  const nextParam = safeRelativePath(searchParams.get("next"));
 
   const [email, setEmail] = React.useState("");
   const [password, setPassword] = React.useState("");
@@ -58,7 +52,7 @@ function LoginForm() {
         return;
       }
       const data = await res.json() as { role?: string };
-      const dest = nextParam ?? ROLE_PATH[data.role ?? ""] ?? "/member";
+      const dest = nextParam ?? homePathForRole(data.role);
       router.push(dest as Parameters<typeof router.push>[0]);
       router.refresh();
     } catch {

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { createSupabaseClient } from "@/lib/auth/client";
+import { homePathForRole, safeRelativePath } from "@/lib/auth/role-path";
 import { useSearchParams, useRouter } from "next/navigation";
 import { Loader2, Mail, Lock, User, AlertCircle, CheckCircle2 } from "lucide-react";
 import Link from "next/link";
@@ -12,7 +13,7 @@ function SignupForm() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const token = searchParams.get("token");
-  const next = searchParams.get("next") ?? "/member";
+  const next = safeRelativePath(searchParams.get("next"));
 
   const [invite, setInvite] = React.useState<InviteInfo | null>(null);
   const [tokenError, setTokenError] = React.useState<string | null>(null);
@@ -56,6 +57,9 @@ function SignupForm() {
     setStatus("loading");
 
     const supabase = createSupabaseClient();
+    const callbackUrl = new URL("/api/auth/callback", location.origin);
+    if (next) callbackUrl.searchParams.set("next", next);
+
     const { data, error } = await supabase.auth.signUp({
       email: email.trim(),
       password,
@@ -66,7 +70,7 @@ function SignupForm() {
           role: invite.role,
           invite_token: token,
         },
-        emailRedirectTo: `${location.origin}/api/auth/callback?next=${encodeURIComponent(next)}`,
+        emailRedirectTo: callbackUrl.toString(),
       },
     });
 
@@ -80,7 +84,14 @@ function SignupForm() {
     await fetch(`/api/admin/invites/${token}`, { method: "PATCH" }).catch(() => {});
 
     if (data.session) {
-      router.push(next as Parameters<typeof router.push>[0]);
+      let role = invite.role;
+      const res = await fetch("/api/auth/me").catch(() => null);
+      if (res?.ok) {
+        const me = await res.json().catch(() => ({})) as { role?: string };
+        role = me.role ?? role;
+      }
+      const dest = next ?? homePathForRole(role);
+      router.push(dest as Parameters<typeof router.push>[0]);
       router.refresh();
     } else {
       setStatus("done");
@@ -214,7 +225,7 @@ function SignupForm() {
 
       <p className="mt-6 text-center text-[12px] text-slate-500">
         すでにアカウントをお持ちの方は{" "}
-        <Link href={`/login?next=${encodeURIComponent(next)}` as never} className="font-semibold text-slate-900 underline underline-offset-2">
+        <Link href={(next ? `/login?next=${encodeURIComponent(next)}` : "/login") as never} className="font-semibold text-slate-900 underline underline-offset-2">
           ログイン
         </Link>
       </p>

--- a/src/lib/auth/__tests__/role-path.test.ts
+++ b/src/lib/auth/__tests__/role-path.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { homePathForRole, safeRelativePath } from "../role-path";
+
+describe("homePathForRole", () => {
+  it("maps each known role to its home path", () => {
+    expect(homePathForRole("super")).toBe("/super");
+    expect(homePathForRole("admin")).toBe("/admin");
+    expect(homePathForRole("manager")).toBe("/manager");
+    expect(homePathForRole("member")).toBe("/member");
+  });
+
+  it("falls back to the member home for missing or unknown roles", () => {
+    expect(homePathForRole(null)).toBe("/member");
+    expect(homePathForRole(undefined)).toBe("/member");
+    expect(homePathForRole("unknown")).toBe("/member");
+  });
+});
+
+describe("safeRelativePath", () => {
+  it("accepts same-origin relative paths", () => {
+    expect(safeRelativePath("/manager")).toBe("/manager");
+    expect(safeRelativePath("/member?tab=activity")).toBe("/member?tab=activity");
+  });
+
+  it("rejects missing, absolute, and protocol-relative paths", () => {
+    expect(safeRelativePath(null)).toBeNull();
+    expect(safeRelativePath("https://example.com")).toBeNull();
+    expect(safeRelativePath("//example.com")).toBeNull();
+    expect(safeRelativePath("member")).toBeNull();
+  });
+});

--- a/src/lib/auth/role-path.ts
+++ b/src/lib/auth/role-path.ts
@@ -1,0 +1,17 @@
+export const DEFAULT_ROLE_HOME_PATH = "/member";
+
+export const ROLE_HOME_PATHS: Record<string, string> = {
+  super: "/super",
+  admin: "/admin",
+  manager: "/manager",
+  member: DEFAULT_ROLE_HOME_PATH,
+};
+
+export function homePathForRole(role: string | null | undefined): string {
+  return ROLE_HOME_PATHS[role ?? ""] ?? DEFAULT_ROLE_HOME_PATH;
+}
+
+export function safeRelativePath(path: string | null | undefined): string | null {
+  if (!path || !path.startsWith("/") || path.startsWith("//")) return null;
+  return path;
+}


### PR DESCRIPTION
## Summary
- Route login destinations through a shared role-to-home helper.
- Stop defaulting signup confirmation redirects to `/member` when no explicit `next` is provided.
- Resolve the authenticated app user role in `/api/auth/callback` after Supabase session exchange, including email-based linking for invite-created users.
- Reject absolute/protocol-relative `next` values before redirecting.

Closes #129

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`

## Risk notes
- Explicit same-origin relative `next` still takes precedence.
- Missing/unknown roles still fall back to `/member`.
- Callback role lookup uses the existing service-role users lookup pattern already used by `/api/auth/me`.