### PR TITLE
Use JST for analytics month and date defaults

### DIFF
--- a/src/app/api/daily-logs/route.ts
+++ b/src/app/api/daily-logs/route.ts
@@ -2,6 +2,7 @@ import { ok, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
 import { expandRoute, expandAssignedRoute } from "@/lib/workflow";
 import { requireAppUser } from "@/lib/api/auth";
+import { jstDateString, jstTimeHHMM } from "@/lib/time";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -44,7 +45,7 @@ export async function POST(req: Request) {
   if (sess instanceof Response) return sess;
   const b = await readJson<CreateBody>(req);
   const userId = sess.userId;
-  const date = b.date ?? new Date().toISOString().slice(0, 10);
+  const date = b.date ?? jstDateString();
   const repos = getRepos();
 
   const expenses = (b.expenses ?? []).filter((e) => e.amount > 0 && e.purpose?.trim());
@@ -58,7 +59,7 @@ export async function POST(req: Request) {
   });
 
   // 各活動を登録
-  const time = new Date().toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" });
+  const time = jstTimeHHMM();
   const createdActivities = [];
   for (const a of (Array.isArray(b.activities) ? b.activities : [])) {
     const created = await repos.activityLogs.create({

--- a/src/app/api/expenses/route.ts
+++ b/src/app/api/expenses/route.ts
@@ -2,6 +2,7 @@ import { ok, bad, readJson } from "@/lib/api/http";
 import { getRepos } from "@/lib/db/repositories";
 import { expandRoute, expandAssignedRoute } from "@/lib/workflow";
 import { requireAppUser } from "@/lib/api/auth";
+import { jstDateString } from "@/lib/time";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -35,7 +36,7 @@ export async function POST(req: Request) {
   // ADR-021: daily_log_id の解決 — 明示指定 > 当日 upsert
   let dailyLogId = b.dailyLogId;
   if (!dailyLogId) {
-    const date = b.date ?? new Date().toISOString().slice(0, 10);
+    const date = b.date ?? jstDateString();
     const dl = await repos.dailyLogs.upsert(userId, date);
     dailyLogId = dl.id;
   }

--- a/src/lib/__tests__/time.test.ts
+++ b/src/lib/__tests__/time.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { jstDateString, jstFiscalYear, jstMonthDay, jstTimeHHMM, jstYearMonth } from "../time";
+
+describe("JST time helpers", () => {
+  it("uses the JST calendar date near UTC month boundaries", () => {
+    const jstMorningAtMonthStart = new Date("2026-06-30T23:59:00Z");
+
+    expect(jstDateString(jstMorningAtMonthStart)).toBe("2026-07-01");
+    expect(jstYearMonth(0, jstMorningAtMonthStart)).toBe("2026-07");
+    expect(jstYearMonth(-1, jstMorningAtMonthStart)).toBe("2026-06");
+  });
+
+  it("formats JST clock and month/day labels", () => {
+    const date = new Date("2026-06-30T15:05:00Z");
+
+    expect(jstTimeHHMM(date)).toBe("00:05");
+    expect(jstMonthDay(date)).toBe("7/1");
+  });
+
+  it("calculates fiscal year by JST date", () => {
+    expect(jstFiscalYear(new Date("2026-03-31T15:00:00Z"))).toBe("2026");
+    expect(jstFiscalYear(new Date("2026-03-31T14:59:00Z"))).toBe("2025");
+  });
+});

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -14,13 +14,13 @@ export const DEFAULT_ALLOCATION: Record<string, number> = {
   その他: 100000,
 };
 
+import { jstFiscalYear } from "@/lib/time";
+
 export const ANNUAL_BUDGET_TOTAL = 2000000;
 
 /** 現在の年度(4 月始まり)を "YYYY" で返す。例: 2026-06 → "2026"、2026-02 → "2025"。 */
 export function currentFiscalYear(d: Date = new Date()): string {
-  const y = d.getFullYear();
-  const m = d.getMonth() + 1; // 1-12
-  return String(m >= 4 ? y : y - 1);
+  return jstFiscalYear(d);
 }
 
 /** 既定配分を upsert 用の配列に変換 */

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -29,6 +29,7 @@ import type {
   BudgetLineDTO,
 } from "./types";
 import { BUDGET_CATEGORIES, DEFAULT_ALLOCATION, currentFiscalYear } from "@/lib/budget";
+import { jstDateString, jstTimeHHMM, jstYearMonth } from "@/lib/time";
 
 // SQLite 実装(ローカル / Vercel デモ)。SQL はここに集約し、Route からは追放する。
 const MUNI = "muni_shinonsen";
@@ -41,10 +42,7 @@ function muniOf(userId: string): string {
 
 // 当月 / N ヶ月前の 'YYYY-MM' を返す(ローカル時刻基準)
 function ymOffset(offset: number): string {
-  const d = new Date();
-  d.setDate(1);
-  d.setMonth(d.getMonth() + offset);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+  return jstYearMonth(offset);
 }
 
 // municipalities の contract_* 専用カラム → ContractDTO に合成
@@ -651,8 +649,8 @@ export const sqliteRepos: Repos = {
     },
     async create(b) {
       const id = genId("log");
-      const date = b.date ?? new Date().toISOString().slice(0, 10);
-      const time = b.time ?? new Date().toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" });
+      const date = b.date ?? jstDateString();
+      const time = b.time ?? jstTimeHHMM();
       // ADR-021: 活動作成時に当日の daily_log を自動 upsert し daily_log_id を結線する
       const muni = muniOf(b.userId);
       let dailyLogId = b.dailyLogId ?? null;
@@ -711,7 +709,7 @@ export const sqliteRepos: Repos = {
       run(
         `INSERT INTO expenses (id,user_id,municipality_id,expense_kind,category,daily_log_id,title,amount_requested,purpose,status,ai_note,citations,has_receipt,receipt_key,created_at)
          VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
-        [id, b.userId, muniOf(b.userId), "single", b.category ?? "活動費", b.dailyLogId ?? null, b.title, b.amount, b.purpose, b.status ?? "申請中", "AI 判定材料は申請後に表示されます。", JSON.stringify([]), b.receiptKey ? 1 : 0, b.receiptKey ?? null, new Date().toISOString().slice(0, 10)]
+        [id, b.userId, muniOf(b.userId), "single", b.category ?? "活動費", b.dailyLogId ?? null, b.title, b.amount, b.purpose, b.status ?? "申請中", "AI 判定材料は申請後に表示されます。", JSON.stringify([]), b.receiptKey ? 1 : 0, b.receiptKey ?? null, jstDateString()]
       );
       return mapExpense(all("SELECT * FROM expenses WHERE id=?", [id])[0]);
     },
@@ -728,7 +726,7 @@ export const sqliteRepos: Repos = {
           b.title, b.amount, b.purpose, b.status ?? "申請中",
           "日報経由の経費(ADR-014)。AI 判定材料は申請後に表示されます。",
           JSON.stringify([]), b.hasReceipt ? 1 : 0, b.receiptKey ?? null,
-          new Date().toISOString().slice(0, 10),
+          jstDateString(),
         ]
       );
       return mapExpense(all("SELECT * FROM expenses WHERE id=?", [id])[0]);

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -32,15 +32,13 @@ import type {
   BudgetLineDTO,
 } from "./types";
 import { BUDGET_CATEGORIES, DEFAULT_ALLOCATION, currentFiscalYear } from "@/lib/budget";
+import { jstDateString, jstTimeHHMM, jstYearMonth } from "@/lib/time";
 
 const MUNI = "10000000-0000-4000-8000-000000000001";
 
 // 当月 / N ヶ月前の 'YYYY-MM' を返す(ローカル時刻基準)
 function ymOffset(offset: number): string {
-  const d = new Date();
-  d.setDate(1);
-  d.setMonth(d.getMonth() + offset);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+  return jstYearMonth(offset);
 }
 
 // 'YYYY-MM' → JST 月初・翌月初の ISO 文字列([gte, lt) 範囲)。
@@ -159,17 +157,18 @@ async function muniOf(userId: string): Promise<string> {
 // Supabase の occurred_at(timestamptz)→ log_date / log_time に変換してマッパーに渡す
 function toLogRow(r: Record<string, unknown>): Record<string, unknown> {
   const oa = r.occurred_at as string | null;
+  const occurredAt = oa ? new Date(oa) : null;
   return {
     ...r,
-    log_date: oa ? oa.slice(0, 10) : r.log_date,
-    log_time: oa ? oa.slice(11, 16) : r.log_time ?? "",
+    log_date: occurredAt ? jstDateString(occurredAt) : r.log_date,
+    log_time: occurredAt ? jstTimeHHMM(occurredAt) : r.log_time ?? "",
   };
 }
 
 // occurred_at を生成(date + time → ISO 文字列)
 function toOccurredAt(date?: string, time?: string): string {
-  const d = date ?? new Date().toISOString().slice(0, 10);
-  const t = time ?? new Date().toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" });
+  const d = date ?? jstDateString();
+  const t = time ?? jstTimeHHMM();
   return `${d}T${t}:00+09:00`;
 }
 
@@ -857,7 +856,7 @@ export const supabaseRepos: Repos = {
     },
     async create(b) {
       const occurredAt = toOccurredAt(b.date, b.time);
-      const date = b.date ?? new Date().toISOString().slice(0, 10);
+      const date = b.date ?? jstDateString();
       // daily_log を upsert して daily_log_id を結線
       let dailyLogId = b.dailyLogId ?? null;
       if (!dailyLogId) {

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,56 @@
+const JST_TIME_ZONE = "Asia/Tokyo";
+
+type DateParts = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+function partsOf(date: Date): Record<string, string> {
+  return Object.fromEntries(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone: JST_TIME_ZONE,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(date).map((part) => [part.type, part.value])
+  );
+}
+
+export function jstDateParts(date: Date = new Date()): DateParts {
+  const parts = partsOf(date);
+  return {
+    year: Number(parts.year),
+    month: Number(parts.month),
+    day: Number(parts.day),
+  };
+}
+
+export function jstDateString(date: Date = new Date()): string {
+  const { year, month, day } = jstDateParts(date);
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+export function jstTimeHHMM(date: Date = new Date()): string {
+  const parts = partsOf(date);
+  return `${parts.hour}:${parts.minute}`;
+}
+
+export function jstMonthDay(date: Date = new Date()): string {
+  const { month, day } = jstDateParts(date);
+  return `${month}/${day}`;
+}
+
+export function jstYearMonth(offset = 0, date: Date = new Date()): string {
+  const { year, month } = jstDateParts(date);
+  const shifted = new Date(Date.UTC(year, month - 1 + offset, 1));
+  return `${shifted.getUTCFullYear()}-${String(shifted.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+export function jstFiscalYear(date: Date = new Date()): string {
+  const { year, month } = jstDateParts(date);
+  return String(month >= 4 ? year : year - 1);
+}

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -2,6 +2,7 @@
 // クライアント状態機械をサーバへ移植したもの。
 
 import type { RouteDTO } from "@/lib/db/repositories/types";
+import { jstMonthDay } from "@/lib/time";
 
 export type ApproverType = "dept" | "host_org" | "admin";
 export type StepStatus = "waiting" | "pending" | "approved" | "rejected";
@@ -59,7 +60,7 @@ export function expandAssignedRoute(route: RouteDTO): { routeName: string; steps
 }
 
 const today = () =>
-  new Date().toLocaleDateString("ja-JP", { month: "numeric", day: "numeric" });
+  jstMonthDay();
 
 // 承認:現ステップを approved に。次があれば pending、無ければ全体 approved。
 export function applyApprove(steps: ApprovalStep[], currentStep: number, actor?: DecisionActor) {


### PR DESCRIPTION
## Summary
- Add shared JST date/time helpers for date strings, HH:mm, month labels, and fiscal year boundaries.
- Make sqlite/supabase analytics `ymOffset()` use the JST calendar month so JST month-start mornings no longer show the previous month.
- Use JST defaults for daily log/activity creation, expense daily-log linking, sqlite expense created dates, and approval decision display labels.
- Convert Supabase `occurred_at` back to log date/time through JST instead of slicing the UTC timestamp.

Closes #97

## Validation
- `npx vitest run src/lib/__tests__/time.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`

## Risk notes
- Stored instants such as `generatedAt`, audit timestamps, invite usage, and generic updated_at remain UTC instants.
- Existing explicit `date`/`time` inputs still take precedence over generated defaults.
- Build still emits existing Turbopack workspace/root and middleware convention warnings.