### PR TITLE
fix: 月報再提出時に承認詳細をリフレッシュ

### DIFF
--- a/src/app/api/monthly-reports/__tests__/dedup-resubmit.test.ts
+++ b/src/app/api/monthly-reports/__tests__/dedup-resubmit.test.ts
@@ -43,6 +43,10 @@ describe("月報 再提出の二重キュー防止", () => {
       (a) => a.kind === "月次報告" && a.applicantId === "m2"
     );
     expect(pendingAfter2.length).toBe(1); // 二重化しない
+    expect(pendingAfter2[0]?.detail).toMatchObject({
+      body: "修正後の本文(再提出)",
+      plan: "",
+    });
   });
 
   it("別の月は別の承認キューになる", async () => {

--- a/src/app/api/monthly-reports/route.ts
+++ b/src/app/api/monthly-reports/route.ts
@@ -38,6 +38,7 @@ export async function POST(req: Request) {
   // なりすまし防止: 提出者はセッション本人に固定(body の userId は受け付けない)
   const userId = sess.userId;
   const report = await repos.monthlyReports.submit({ userId, ym: b.ym, markdown: b.markdown.trim(), plan: b.plan?.trim() });
+  const detail = { kind: "月次報告", ym: b.ym, body: b.markdown.trim(), plan: b.plan?.trim() ?? "" };
 
   // 再提出時の二重キュー防止: 同一隊員・同月の月次報告が既に承認待ちなら再エンキューしない。
   // submit() は同月を上書きするため report.id は不変。役場は既存の承認1件で再提出後の内容も確認できる。
@@ -47,7 +48,9 @@ export async function POST(req: Request) {
   );
 
   // 役場側の承認キューに投入(月次報告 ルート)
-  if (!alreadyQueued) {
+  if (alreadyQueued) {
+    await repos.approvals.updateDetail("monthly_reports", report.id, detail);
+  } else {
     const memberName = (await repos.users.nameOf(userId)) ?? "隊員";
     const { routeName, steps } = expandRoute("月次報告", "担当課");
     await repos.approvals.enqueue({
@@ -57,7 +60,7 @@ export async function POST(req: Request) {
       memberName,
       title,
       ai: "隊員が提出した月次報告。活動ログから AI 生成・本人確認済み。",
-      detail: { kind: "月次報告", ym: b.ym, body: b.markdown.trim(), plan: b.plan?.trim() ?? "" },
+      detail,
       routeName,
       steps,
       targetTable: "monthly_reports",

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -790,6 +790,12 @@ export const sqliteRepos: Repos = {
     async getRaw(id) {
       return get<ApprovalRaw>("SELECT id,municipality_id,kind,steps,current_step,status,target_table,target_id FROM approvals WHERE id=?", [id]);
     },
+    async updateDetail(targetTable, targetId, detail) {
+      run(
+        "UPDATE approvals SET detail=? WHERE target_table=? AND target_id=? AND status='pending'",
+        [JSON.stringify(detail), targetTable, targetId]
+      );
+    },
     async updateState(id, steps, currentStep, status, decision) {
       if (decision) {
         run("UPDATE approvals SET steps=?, current_step=?, status=?, decided_by=?, decided_at=datetime('now'), comment=? WHERE id=?", [

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -1141,6 +1141,14 @@ export const supabaseRepos: Repos = {
         target_id: data.target_id ?? null,
       };
     },
+    async updateDetail(targetTable, targetId, detail) {
+      await supabase()
+        .from("approvals")
+        .update({ detail })
+        .eq("target_table", targetTable)
+        .eq("target_id", targetId)
+        .eq("status", "pending");
+    },
     async updateState(id, steps, currentStep, status, decision) {
       await supabase()
         .from("approvals")

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -291,6 +291,7 @@ export interface Repos {
   approvals: {
     listPending(muni: string): Promise<ApprovalDTO[]>;
     getRaw(id: string): Promise<ApprovalRaw | undefined>;
+    updateDetail(targetTable: string, targetId: string, detail: unknown): Promise<void>;
     updateState(
       id: string,
       steps: unknown[],


### PR DESCRIPTION
定期クリーンアップで発掘した develop 未反映の修正。レビュー後に develop へ取り込み。