### PR TITLE
feat: super招待のprovisioning整合+自治体詳細に管理者招待導線 (#65残差分)

### DIFF
--- a/src/app/api/super/municipalities/[id]/admins/__tests__/route.test.ts
+++ b/src/app/api/super/municipalities/[id]/admins/__tests__/route.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { get, run, genId } from "@/lib/db";
+
+// #65: POST /api/super/municipalities/[id]/admins の回帰テスト。
+// super による任意自治体への admin pre-provision + 招待発行が
+// 冪等(同 email 再招待)・ROLE_CONFLICT 検知・email 小文字正規化(#74)を満たすこと。
+const MUNI_TARGET = "muni_test_admins_target";
+let superId = "";
+let memberEmail = "";
+
+function loadRoute() {
+  vi.resetModules();
+  return import("../route");
+}
+
+function post(body: unknown, id = MUNI_TARGET) {
+  return {
+    req: new Request(`http://test/api/super/municipalities/${id}/admins`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    ctx: { params: Promise.resolve({ id }) },
+  };
+}
+
+function stubRole(role: string, userId: string) {
+  vi.stubEnv("AUTH_PROVIDER", "none");
+  vi.stubEnv("DEV_USER_ROLE", role);
+  vi.stubEnv("DEV_USER_ID", userId);
+}
+
+beforeAll(() => {
+  run("INSERT INTO municipalities (id,name,prefecture,annual_budget) VALUES (?,?,?,?)", [
+    MUNI_TARGET,
+    "Admins Target Town",
+    "Test Prefecture",
+    1000000,
+  ]);
+  superId = genId("sup");
+  run(
+    "INSERT INTO users (id,municipality_id,organization_type,role,name,email,status) VALUES (?,?,?,?,?,?,?)",
+    [superId, "muni_shinonsen", "municipality", "super", "Super Ops", "superops@ops.example.jp", "active"]
+  );
+  // ROLE_CONFLICT 用: 対象自治体に member として存在する email
+  const memberId = genId("m");
+  memberEmail = `${memberId}@member.example.jp`;
+  run(
+    "INSERT INTO users (id,municipality_id,organization_type,role,name,email,status) VALUES (?,?,?,?,?,?,?)",
+    [memberId, MUNI_TARGET, "member", "member", "Member T", memberEmail, "active"]
+  );
+});
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("POST /api/super/municipalities/[id]/admins", () => {
+  it("super で POST すると 201 で token/url/expiresAt を返し、users 行を対象自治体に role=admin で作る", async () => {
+    stubRole("super", superId);
+    const mod = await loadRoute();
+    const { req, ctx } = post({ email: "newadmin@example.jp", name: "新規 管理者" });
+    const res = await mod.POST(req, ctx);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { token: string; url: string; expiresAt: string };
+    expect(body.token).toMatch(/^[0-9a-f]{48}$/);
+    expect(body.url).toContain(`/signup?token=${body.token}`);
+    expect(new Date(body.expiresAt).getTime()).toBeGreaterThan(Date.now());
+
+    const row = get<{ municipality_id: string; role: string; status: string }>(
+      "SELECT municipality_id, role, status FROM users WHERE email=?",
+      ["newadmin@example.jp"]
+    );
+    expect(row?.municipality_id).toBe(MUNI_TARGET);
+    expect(row?.role).toBe("admin");
+    expect(row?.status).toBe("active");
+  });
+
+  it("同一リクエストを 2 回送ってもどちらも 2xx で users 行は重複しない", async () => {
+    stubRole("super", superId);
+    const mod = await loadRoute();
+    const email = "twiceadmin@example.jp";
+
+    const a = post({ email, name: "二回 管理者" });
+    const first = await mod.POST(a.req, a.ctx);
+    expect(first.status).toBe(201);
+    const b = post({ email, name: "二回 管理者" });
+    const second = await mod.POST(b.req, b.ctx);
+    expect(second.status).toBe(201);
+
+    const count = get<{ c: number }>("SELECT COUNT(*) c FROM users WHERE email=?", [email]);
+    expect(count?.c).toBe(1);
+  });
+
+  it("その自治体に member として存在する email は 409 を返す", async () => {
+    stubRole("super", superId);
+    const mod = await loadRoute();
+    const { req, ctx } = post({ email: memberEmail, name: "競合 管理者" });
+    const res = await mod.POST(req, ctx);
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("このメールアドレスは既に別の権限で登録されています");
+  });
+
+  it("admin role で呼ぶと 403", async () => {
+    stubRole("admin", "adm1");
+    const mod = await loadRoute();
+    const { req, ctx } = post({ email: "blocked@example.jp", name: "不許可" });
+    const res = await mod.POST(req, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("member role で呼ぶと 403", async () => {
+    stubRole("member", "m1");
+    const mod = await loadRoute();
+    const { req, ctx } = post({ email: "blocked2@example.jp", name: "不許可" });
+    const res = await mod.POST(req, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("email 欠落は 400", async () => {
+    stubRole("super", superId);
+    const mod = await loadRoute();
+    const { req, ctx } = post({ name: "名前だけ" });
+    const res = await mod.POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("name 欠落は 400", async () => {
+    stubRole("super", superId);
+    const mod = await loadRoute();
+    const { req, ctx } = post({ email: "noname@example.jp" });
+    const res = await mod.POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("大文字混じり email は小文字で保存され、小文字での再招待も冪等(#74)", async () => {
+    stubRole("super", superId);
+    const mod = await loadRoute();
+
+    const a = post({ email: "Admin@Example.JP", name: "大文字 管理者" });
+    const first = await mod.POST(a.req, a.ctx);
+    expect(first.status).toBe(201);
+    const stored = get<{ email: string }>("SELECT email FROM users WHERE email=?", ["admin@example.jp"]);
+    expect(stored?.email).toBe("admin@example.jp");
+
+    const b = post({ email: "admin@example.jp", name: "大文字 管理者" });
+    const second = await mod.POST(b.req, b.ctx);
+    expect(second.status).toBe(201);
+    const count = get<{ c: number }>("SELECT COUNT(*) c FROM users WHERE email=?", ["admin@example.jp"]);
+    expect(count?.c).toBe(1);
+  });
+});

--- a/src/app/api/super/municipalities/[id]/admins/route.ts
+++ b/src/app/api/super/municipalities/[id]/admins/route.ts
@@ -14,13 +14,26 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
   if (sess instanceof Response) return sess;
   const { id } = await params;
   const b = await readJson<Body>(req);
-  if (!b.email?.trim() || !b.name?.trim()) return bad("email / name は必須です");
-  const inv = await getRepos().super.createAdminInvite({
-    municipalityId: id,
-    email: b.email.trim(),
-    name: b.name.trim(),
-    createdBy: sess.userId,
-  });
+  // Supabase Auth は email を小文字化して保持し、/api/auth/me は完全一致で紐づける。
+  // pre-provision する users.email も小文字に正規化しないと大文字を含む招待で 403 が再発する(#74)。
+  const cleanEmail = b.email?.trim().toLowerCase();
+  const cleanName = b.name?.trim();
+  if (!cleanEmail || !cleanName) return bad("email / name は必須です");
+  let inv: { token: string; expiresAt: string };
+  try {
+    inv = await getRepos().super.createAdminInvite({
+      municipalityId: id,
+      email: cleanEmail,
+      name: cleanName,
+      createdBy: sess.userId,
+    });
+  } catch (e) {
+    // 同じ email が別ロールで登録済み → サイレントに権限を取り違えないよう明示エラー。
+    if (e instanceof Error && e.message === "ROLE_CONFLICT") {
+      return bad("このメールアドレスは既に別の権限で登録されています", 409);
+    }
+    return bad("DB error", 500);
+  }
   const url = `${new URL(req.url).origin}/signup?token=${inv.token}`;
   return ok({ ...inv, url }, 201);
 }

--- a/src/app/super/_app.tsx
+++ b/src/app/super/_app.tsx
@@ -163,7 +163,11 @@ export function SuperApp() {
       )}
       {/* #65 管理者招待モーダル */}
       {inviteFor && (
-        <InviteModal muni={inviteFor} onClose={() => setInviteFor(null)} onDone={loadOverview} />
+        <InviteModal
+          muni={inviteFor}
+          onClose={() => setInviteFor(null)}
+          onDone={() => { loadOverview(); if (detailId) openDetail(detailId); }}
+        />
       )}
 
       {/* #66 自治体ドリルダウン スライドオーバー */}
@@ -174,6 +178,7 @@ export function SuperApp() {
           onClose={() => setDetailId(null)}
           onReload={() => { if (detailId) openDetail(detailId); loadOverview(); }}
           onAfterDelete={() => { setDetailId(null); loadOverview(); }}
+          onInvite={(m) => setInviteFor(m)}
           municipalities={data?.municipalities ?? []}
           onOverviewRefresh={loadOverview}
         />
@@ -277,6 +282,7 @@ function DetailSheet({
   onClose,
   onReload,
   onAfterDelete,
+  onInvite,
   municipalities,
   onOverviewRefresh,
 }: {
@@ -285,6 +291,7 @@ function DetailSheet({
   onClose: () => void;
   onReload: () => void;
   onAfterDelete: () => void;
+  onInvite: (m: { id: string; name: string }) => void;
   municipalities: MuniRow[];
   onOverviewRefresh: () => void;
 }) {
@@ -332,6 +339,12 @@ function DetailSheet({
                   className="inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-[11px] font-semibold text-slate-700 hover:bg-slate-100"
                 >
                   <Pencil className="h-3 w-3" /> 編集
+                </button>
+                <button
+                  onClick={() => onInvite({ id: detail.municipality.id, name: detail.municipality.name })}
+                  className="inline-flex items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-[11px] font-semibold text-slate-700 hover:bg-slate-100"
+                >
+                  <UserPlus className="h-3 w-3" /> 管理者を招待
                 </button>
                 <button
                   onClick={remove}

--- a/src/lib/db/__tests__/super.test.ts
+++ b/src/lib/db/__tests__/super.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { get, run } from "@/lib/db";
 import { sqliteRepos } from "@/lib/db/repositories/sqlite";
 
 // super(運営者)リポジトリ層のユニットテスト。
@@ -80,6 +81,70 @@ describe("super.createAdminInvite", () => {
     expect(admin?.role).toBe("admin");
     expect(admin?.status).toBe("active");
     expect(admin?.municipalityId).toBe(muni.id);
+  });
+
+  it("同 email + role=admin の再招待は冪等(users 1 行のまま・新トークン発行)", async () => {
+    const muni = await sqliteRepos.super.createMunicipality({ name: "再招待町", prefecture: "兵庫県" });
+    const email = "readmin@example.com";
+    const first = await sqliteRepos.super.createAdminInvite({
+      municipalityId: muni.id, email, name: "再招待 太郎", createdBy: "u_super",
+    });
+    const second = await sqliteRepos.super.createAdminInvite({
+      municipalityId: muni.id, email, name: "再招待 太郎", createdBy: "u_super",
+    });
+
+    expect(second.token).toMatch(/^[0-9a-f]{48}$/);
+    expect(second.token).not.toBe(first.token);
+    const count = get<{ c: number }>("SELECT COUNT(*) c FROM users WHERE email=?", [email]);
+    expect(count?.c).toBe(1);
+  });
+
+  it("retired にした admin を再招待すると active に戻る", async () => {
+    const muni = await sqliteRepos.super.createMunicipality({ name: "復帰町", prefecture: "兵庫県" });
+    const email = "retired-admin@example.com";
+    await sqliteRepos.super.createAdminInvite({
+      municipalityId: muni.id, email, name: "復帰 花子", createdBy: "u_super",
+    });
+    run("UPDATE users SET status='retired' WHERE email=?", [email]);
+
+    await sqliteRepos.super.createAdminInvite({
+      municipalityId: muni.id, email, name: "復帰 花子", createdBy: "u_super",
+    });
+
+    const row = get<{ status: string }>("SELECT status FROM users WHERE email=?", [email]);
+    expect(row?.status).toBe("active");
+  });
+
+  it("既に member として存在する email は ROLE_CONFLICT で弾く", async () => {
+    const muni = await sqliteRepos.super.createMunicipality({ name: "競合町", prefecture: "兵庫県" });
+    await expect(
+      sqliteRepos.super.createAdminInvite({
+        municipalityId: muni.id,
+        email: "m1@member.example.jp", // seed の隊員
+        name: "競合 次郎",
+        createdBy: "u_super",
+      })
+    ).rejects.toThrow("ROLE_CONFLICT");
+  });
+
+  it("新規 email は対象自治体(作成者の自治体ではない)に provisioning される", async () => {
+    const muni = await sqliteRepos.super.createMunicipality({ name: "対象町", prefecture: "兵庫県" });
+    const email = "target-admin@example.com";
+    // createdBy に seed の adm1(muni_shinonsen 所属)を使い、対象自治体が優先されることを確認する
+    const res = await sqliteRepos.super.createAdminInvite({
+      municipalityId: muni.id, email, name: "対象 三郎", createdBy: "adm1",
+    });
+
+    const user = get<{ municipality_id: string }>("SELECT municipality_id FROM users WHERE email=?", [email]);
+    expect(user?.municipality_id).toBe(muni.id);
+    expect(user?.municipality_id).not.toBe(SEED_MUNI);
+
+    const inv = get<{ role: string; municipality_name: string }>(
+      "SELECT role, municipality_name FROM invite_tokens WHERE token=?",
+      [res.token]
+    );
+    expect(inv?.role).toBe("admin");
+    expect(inv?.municipality_name).toBe("対象町");
   });
 });
 

--- a/src/lib/db/repositories/sqlite.ts
+++ b/src/lib/db/repositories/sqlite.ts
@@ -197,19 +197,16 @@ export const sqliteRepos: Repos = {
 
     async createAdminInvite(a) {
       const muni = get<{ name: string }>("SELECT name FROM municipalities WHERE id=?", [a.municipalityId]);
-      // admin を pre-provision(/api/auth/me が email で auth_id を紐づけられるよう先に行を作る)
-      run(
-        `INSERT INTO users (id,municipality_id,organization_type,role,name,email,status)
-         VALUES (?,?,?,?,?,?,?)`,
-        [genId("adm"), a.municipalityId, "municipality", "admin", a.name, a.email, "active"]
-      );
-      const token = Array.from(crypto.getRandomValues(new Uint8Array(24))).map((b) => b.toString(16).padStart(2, "0")).join("");
-      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
-      run(
-        `INSERT INTO invite_tokens (token,email,role,municipality_name,created_by,expires_at) VALUES (?,?,?,?,?,?)`,
-        [token, a.email, "admin", muni?.name ?? "", a.createdBy, expiresAt]
-      );
-      return { token, expiresAt };
+      // pre-provision + トークン発行は createProvisioned に委譲する
+      // (ROLE_CONFLICT 検知・同 email+同 role の冪等再有効化を共通化)。
+      return sqliteRepos.invites.createProvisioned({
+        email: a.email,
+        name: a.name,
+        role: "admin",
+        municipalityName: muni?.name ?? "",
+        createdBy: a.createdBy,
+        municipalityId: a.municipalityId,
+      });
     },
 
     async municipalityDetail(municipalityId): Promise<SuperMuniDetail | null> {
@@ -624,24 +621,26 @@ export const sqliteRepos: Repos = {
       );
       return { token, expiresAt };
     },
-    async createProvisioned({ email, name, role, municipalityName, createdBy }) {
+    async createProvisioned({ email, name, role, municipalityName, createdBy, municipalityId }) {
       // email に対応する users 行が無ければ先に作る(/api/auth/me が email で紐づけられるように)。
+      // municipalityId 明示時はその自治体へ provisioning(super は users に不在なので
+      // municipalityOfUser(createdBy) を呼ばずに済むよう ?? の右辺に置いて短絡させる)。
       const existing = get<{ id: string; role: string; municipality_id: string | null }>("SELECT id, role, municipality_id FROM users WHERE email=?", [email]);
       if (existing) {
         // 別ロールでの再招待はサイレントに権限を取り違える。明示的に弾く。
         if (existing.role !== role) throw new Error("ROLE_CONFLICT");
         // 同ロールの再招待は冪等。退職などで無効化されていれば再有効化する。
         run("UPDATE users SET status='active' WHERE id=?", [existing.id]);
-        if (role === "member") seedDefaultBudget(existing.id, existing.municipality_id ?? municipalityOfUser(createdBy));
+        if (role === "member") seedDefaultBudget(existing.id, existing.municipality_id ?? municipalityId ?? municipalityOfUser(createdBy));
       } else {
-        const creatorMuni = municipalityOfUser(createdBy);
+        const targetMuni = municipalityId ?? municipalityOfUser(createdBy);
         const id = genId(role === "member" ? "m" : "s");
         const orgType = role === "member" ? "member" : "municipality";
         run(
           "INSERT INTO users (id,municipality_id,organization_type,role,name,email,status) VALUES (?,?,?,?,?,?,?)",
-          [id, creatorMuni, orgType, role, name, email, "active"]
+          [id, targetMuni, orgType, role, name, email, "active"]
         );
-        if (role === "member") seedDefaultBudget(id, creatorMuni);
+        if (role === "member") seedDefaultBudget(id, targetMuni);
       }
       return sqliteRepos.invites.create({ email, role, municipalityName, createdBy });
     },

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -275,26 +275,16 @@ export const supabaseRepos: Repos = {
 
     async createAdminInvite(a) {
       const { data: muni } = await supabase().from("municipalities").select("name").eq("id", a.municipalityId).maybeSingle();
-      // admin を pre-provision(/api/auth/me が email で auth_id を紐づけられるよう先に行を作る)
-      await supabase().from("users").insert({
-        municipality_id: a.municipalityId,
-        organization_type: "municipality",
-        role: "admin",
+      // pre-provision + トークン発行は createProvisioned に委譲する
+      // (ROLE_CONFLICT 検知・同 email+同 role の冪等再有効化・insert エラー伝播を共通化)。
+      return supabaseRepos.invites.createProvisioned({
+        email: a.email,
         name: a.name,
-        email: a.email,
-        status: "active",
-      });
-      const token = Array.from(crypto.getRandomValues(new Uint8Array(24))).map((b) => b.toString(16).padStart(2, "0")).join("");
-      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
-      await supabase().from("invite_tokens").insert({
-        token,
-        email: a.email,
         role: "admin",
-        municipality_name: muni?.name ?? "",
-        created_by: a.createdBy,
-        expires_at: expiresAt,
+        municipalityName: muni?.name ?? "",
+        createdBy: a.createdBy,
+        municipalityId: a.municipalityId,
       });
-      return { token, expiresAt };
     },
 
     async municipalityDetail(municipalityId): Promise<SuperMuniDetail | null> {
@@ -824,8 +814,10 @@ export const supabaseRepos: Repos = {
       });
       return { token, expiresAt };
     },
-    async createProvisioned({ email, name, role, municipalityName, createdBy }) {
+    async createProvisioned({ email, name, role, municipalityName, createdBy, municipalityId }) {
       // email に対応する users 行が無ければ先に作る(/api/auth/me が email で紐づけられるように)。
+      // municipalityId 明示時はその自治体へ provisioning(super は users に不在なので
+      // municipalityOfUserSb(createdBy) を呼ばずに済むよう ?? の右辺に置いて短絡させる)。
       const { data: existing, error: selErr } = await supabase()
         .from("users")
         .select("id, role, municipality_id")
@@ -842,11 +834,11 @@ export const supabaseRepos: Repos = {
           .eq("id", existing.id);
         if (upErr) throw upErr;
         if (role === "member") {
-          const municipalityId = (existing.municipality_id as string | null) ?? await municipalityOfUserSb(createdBy);
-          await seedDefaultBudgetSb(existing.id as string, municipalityId);
+          const targetMuni = (existing.municipality_id as string | null) ?? municipalityId ?? await municipalityOfUserSb(createdBy);
+          await seedDefaultBudgetSb(existing.id as string, targetMuni);
         }
       } else {
-        const creatorMuni = await municipalityOfUserSb(createdBy);
+        const creatorMuni = municipalityId ?? await municipalityOfUserSb(createdBy);
         const orgType = role === "member" ? "member" : "municipality";
         // insert の失敗(RLS/一意制約等)を握り潰すと users 行が無いままトークンだけ発行され
         // 招待先が後で 403 になる。エラーは投げてルートで 500 にする。

--- a/src/lib/db/repositories/supabase.ts
+++ b/src/lib/db/repositories/supabase.ts
@@ -838,17 +838,17 @@ export const supabaseRepos: Repos = {
           await seedDefaultBudgetSb(existing.id as string, targetMuni);
         }
       } else {
-        const creatorMuni = municipalityId ?? await municipalityOfUserSb(createdBy);
+        const targetMuni = municipalityId ?? await municipalityOfUserSb(createdBy);
         const orgType = role === "member" ? "member" : "municipality";
         // insert の失敗(RLS/一意制約等)を握り潰すと users 行が無いままトークンだけ発行され
         // 招待先が後で 403 になる。エラーは投げてルートで 500 にする。
         const { data: created, error: insErr } = await supabase()
           .from("users")
-          .insert({ municipality_id: creatorMuni, organization_type: orgType, role, name, email, status: "active" })
+          .insert({ municipality_id: targetMuni, organization_type: orgType, role, name, email, status: "active" })
           .select("id")
           .single();
         if (insErr) throw insErr;
-        if (role === "member" && created?.id) await seedDefaultBudgetSb(created.id, creatorMuni);
+        if (role === "member" && created?.id) await seedDefaultBudgetSb(created.id, targetMuni);
       }
       return supabaseRepos.invites.create({ email, role, municipalityName, createdBy });
     },

--- a/src/lib/db/repositories/types.ts
+++ b/src/lib/db/repositories/types.ts
@@ -175,7 +175,10 @@ export interface Repos {
     updateMunicipality(id: string, patch: { name?: string; prefecture?: string; annualBudget?: number }): Promise<{ id: string; name: string; prefecture: string } | null>;
     /** 自治体を削除(所属ユーザーの有無チェックは呼び出し側で行う) */
     deleteMunicipality(id: string): Promise<void>;
-    /** #65: 指定自治体の admin を pre-provision + 招待トークン発行(url は Route 側で付与) */
+    /**
+     * #65: 指定自治体の admin を pre-provision + 招待トークン発行(url は Route 側で付与)。
+     * 実体は invites.createProvisioned への委譲(ROLE_CONFLICT / 同 email+同 role の冪等再有効化)。
+     */
     createAdminInvite(a: { municipalityId: string; email: string; name: string; createdBy: string }): Promise<{ token: string; expiresAt: string }>;
     /** #66: 自治体ドリルダウン詳細(隊員・職員・活動・保留承認) */
     municipalityDetail(municipalityId: string): Promise<SuperMuniDetail | null>;
@@ -233,8 +236,10 @@ export interface Repos {
      * 招待先の users 行を事前作成(email で冪等)してからトークンを発行する。
      * /api/auth/me は email で auth_id を紐づけるだけ(#64)なので、先に行が無いと
      * 招待されても 403 になる(#74)。super.createAdminInvite と同じ pre-provision 方式。
+     * municipalityId 明示時はその自治体へ provisioning する(super が任意自治体を対象にする用)。
+     * 省略時は従来どおり createdBy の所属自治体に provisioning する。
      */
-    createProvisioned(i: { email: string; name: string; role: string; municipalityName: string; createdBy: string }): Promise<{ token: string; expiresAt: string }>;
+    createProvisioned(i: { email: string; name: string; role: string; municipalityName: string; createdBy: string; municipalityId?: string }): Promise<{ token: string; expiresAt: string }>;
     findByToken(token: string): Promise<InviteRow | null>;
     /** used_at が未設定のときだけ使用済みにする */
     markUsed(token: string): Promise<void>;


### PR DESCRIPTION
Refs #65

## 根本原因
super 経由の管理者招待(`POST /api/super/municipalities/[id]/admins`)が `invites.createProvisioned` を通らず無条件に users を insert していたため、(1) 同 email 再招待で users 行が重複、(2) 別ロール既存 email の権限取り違え(ROLE_CONFLICT 未検知)、(3) Supabase 側 insert エラーの握り潰し(行が無いままトークンだけ発行→招待先が 403)、(4) email 未正規化(#74 と同根)が発生していた。

## 変更内容
- `types.ts`: `invites.createProvisioned` に optional `municipalityId` を追加(明示時はその自治体へ provisioning、省略時は従来どおり createdBy の所属自治体)。`super.createAdminInvite` の doc を委譲仕様に更新
- `sqlite.ts` / `supabase.ts`: `createProvisioned` が `municipalityId` に対応(`??` の短絡評価で super の CREATOR_NOT_FOUND を回避)。`super.createAdminInvite` は `createProvisioned` への委譲に置換し、ROLE_CONFLICT 検知・同 email+同 role の冪等再有効化・insert エラー伝播を獲得
- `route.ts`(super/municipalities/[id]/admins): email を trim+lowercase 正規化(#74 の教訓)、ROLE_CONFLICT → 409、その他 DB エラー → 500
- `src/app/super/_app.tsx`: DetailSheet ヘッダに「管理者を招待」ボタンを追加、招待/昇格完了後に開いている detail を再取得
- レビュー反映: `supabase.ts` の変数名 `creatorMuni` → `targetMuni`(sqlite 側と統一、動作変更なし)

## テスト
- `src/lib/db/__tests__/super.test.ts` 拡張: 同 email+role=admin 再招待の冪等性(users 1 行のまま・新 token 発行)、retired admin の再有効化、member 既存 email の ROLE_CONFLICT、新規 email の provisioning 先が対象自治体であること
- 新規 `src/app/api/super/municipalities/[id]/admins/__tests__/route.test.ts`: 201 応答(token/url/expiresAt+users 行検証)、二重リクエストの冪等性、member 既存 email → 409、admin/member ロール → 403、email/name 欠落 → 400、大文字混じり email の小文字保存+小文字再招待の冪等性

## 検証結果
- typecheck: pass
- lint: pass(0 errors、warnings は既存)
- test: pass(28 files / 117 tests)
- build: pass

## マージ順の注記
fix/admin-save-error-168-169(Track B)を先にマージし、本PRはその後rebaseしてからマージする。

## レビュー指摘の扱い
- 反映: supabase.ts の `creatorMuni` → `targetMuni` rename(nit)
- 見送り(nit): 存在しない自治体 id への 404(既存挙動・UI は実在 id のみ使用、フォローアップ候補)/ 再招待時の name 更新(仕様の冪等要件どおり)/ 旧 route 由来の大文字混じり email 行のデータ整理(コード変更不要、フォローアップ issue へ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
